### PR TITLE
Bugfix: comma missing on app/network-config-tls.json file causing an …

### DIFF
--- a/app/network-config-tls.json
+++ b/app/network-config-tls.json
@@ -9,7 +9,7 @@
 			"server-hostname": "orderer1.example.com",
 			"tls_cacerts": "/fabric-docker-compose-svt/crypto-config/ordererOrganizations/example.com/orderers/orderer1.example.com/tls/ca.crt"
 		},{
-			"url": "grpcs://127.0.0.1:9050"
+			"url": "grpcs://127.0.0.1:9050",
 			"server-hostname": "orderer2.example.com",
 			"tls_cacerts": "/fabric-docker-compose-svt/crypto-config/ordererOrganizations/example.com/orderers/orderer2.example.com/tls/ca.crt"
 		}],


### PR DESCRIPTION
Invalid JSON fixed at TLS network configuration file

## Before 

![jsonerror](https://user-images.githubusercontent.com/6706342/31167268-ceda4948-a8f1-11e7-93d7-bd0bbe8ab687.png)

## After

![imagen](https://user-images.githubusercontent.com/6706342/31167307-f399b318-a8f1-11e7-830c-9a884db52d23.png)

