### PR TITLE
Server_hostname missing, iterative insertion of peers in MySQL

### DIFF
--- a/service/blockscanner.js
+++ b/service/blockscanner.js
@@ -158,7 +158,7 @@ function* savePeerlist(channelName){
         peers.name=channelName;
         peers.requests = peerlist._url;
         peers.server_hostname = peerlist._options["grpc.default_authority"];
-        let c= yield sql.getRowByPkOne(`select count(1) as c from peer where name='${peers.name}' and requests='${peers.requests}' and server_hostname='${peers.server_hostname}' `)
+        let c= yield sql.getRowByPkOne(`select count(1) as c from peer where name='${peers.name}' and requests='${peers.requests}' ${peers.server_hostname ? " and server_hostname='" + peers.server_hostname + "'" : '' } `)
         if(c.c==0){
             yield sql.saveRow('peer',peers)
         }

--- a/service/metricservice.js
+++ b/service/metricservice.js
@@ -42,7 +42,7 @@ function getBlockCount(channelName){
 
 function* getPeerData(channelName){
     let peerArray=[]
-    var c1 = yield sql.getRowsBySQlNoCondtion(`select c.name as name,c.requests as requests,c.server_hostname as server_hostname from peer c where c.name='${channelName}'`);
+    var c1 = yield sql.getRowsBySQlNoCondtion(`select DISTINCT c.name as name,c.requests as requests,c.server_hostname as server_hostname from peer c where c.name='${channelName}'`);
     for (var i = 0, len = c1.length; i < len; i++) {
         var item = c1[i];
         peerArray.push({'name':item.channelname,'requests':item.requests,'server_hostname':item.server_hostname})


### PR DESCRIPTION
When the server_hostname is not present, each time the database refreshes a new row for each peer is inserted in the database.

This fix avoids this to prevent the database from growing without even noticing and the UI to get freeze from loading too much registries.

A simple fix in the SQL query. 
![Uploading Screen Shot 2017-12-28 at 16.24.06.png…]()
