### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,10 +92,10 @@ On another terminal.
 
 - `cd blockchain-explorer`
 - `npm install`
-- `cd blockchain-explorer/app/test`
+- `cd app/test`
 - `npm install`
 - `npm run test`
-- `cd blockchain-explorer/client`
+- `cd ../client`
 - `npm install`
 - `npm test -- -u --coverage`
 - `npm run build`

--- a/README.md
+++ b/README.md
@@ -95,8 +95,7 @@ On another terminal.
 - `cd blockchain-explorer/app/test`
 - `npm install`
 - `npm run test`
-- `cd blockchain-explorer`
-- `cd client/`
+- `cd blockchain-explorer/client`
 - `npm install`
 - `npm test -- -u --coverage`
 - `npm run build`

--- a/README.md
+++ b/README.md
@@ -90,11 +90,12 @@ protocol (`grpcs->grpc`) and port (`9051-> 9050`) in the peer url and remove the
 
 On another terminal.
 
+- `cd blockchain-explorer`
+- `npm install`
 - `cd blockchain-explorer/app/test`
 - `npm install`
 - `npm run test`
 - `cd blockchain-explorer`
-- `npm install`
 - `cd client/`
 - `npm install`
 - `npm test -- -u --coverage`


### PR DESCRIPTION
Unable to run test in the given order as the new dependencies (such as log4js) are only install during main/npm install. Then running tests are passed. May be this is not the case for all of the node devs as they might have installed most of them already