### PR TITLE
Fix notifyCount variable reset problem

### DIFF
--- a/client/src/components/Header/HeaderView.js
+++ b/client/src/components/Header/HeaderView.js
@@ -209,7 +209,6 @@ export class HeaderView extends Component {
     switch (drawer) {
       case "notifyDrawer": {
         this.setState({notifyDrawer: true});
-        this.setState({notifyCount: 0});
         break;
       }
       case "adminDrawer": {
@@ -226,6 +225,7 @@ export class HeaderView extends Component {
     switch (drawer) {
       case "notifyDrawer": {
         this.setState({notifyDrawer: false});
+        this.setState({notifyCount: 0});
         break;
       }
       case "adminDrawer": {


### PR DESCRIPTION
Problem Description: When the NotificationsPanel is displayed, the notifyCount variable is set to zero, then the item in the notify list is always increasing, but the notifyCount variable is also incremented. When the NotificationsPanel is hidden, the notify corresponding to the notifyCount variable has already been read.

Solution: Set the notifyCount variable to zero when hiding the NotificationsPanel.