### PR TITLE
Improve explorer db image config...

### DIFF
--- a/app/persistence/postgreSQL/db/createdb.sh
+++ b/app/persistence/postgreSQL/db/createdb.sh
@@ -1,32 +1,50 @@
 #!/usr/bin/env bash
 
-if [[ -z "${DATABASE_USERNAME}" ]]; then
-  USER=$( jq .pg.username pgconfig.json )
-else
-  USER=$DATABASE_USERNAME
-fi
-if [[ -z "${DATABASE_DATABASE}" ]]; then
-  DATABASE=$( jq .pg.database pgconfig.json )
-else
-  DATABASE=$DATABASE_DATABASE
-fi
-if [[ -z "${DATABASE_PASSWORD}" ]]; then
-  PASSWD=$(jq .pg.passwd pgconfig.json | sed "y/\"/'/")
-else
-  PASSWD=$DATABASE_PASSWORD
-fi
+## IF ALREADY CONFIGURED NO NEED TO RECONFIG
+if [ ! -f /${PGDATA}/conf.done ]; then
 
-echo "USER=${USER}"
-echo "DATABASE=${DATABASE}"
-echo "PASSWD=${PASSWD}"
+  if [[ -z "${DATABASE_USERNAME}" ]]; then
+    USER=$( jq .pg.username pgconfig.json )
+  else
+    USER=$DATABASE_USERNAME
+  fi
+  if [[ -z "${DATABASE_DATABASE}" ]]; then
+    DATABASE=$( jq .pg.database pgconfig.json )
+  else
+    DATABASE=$DATABASE_DATABASE
+  fi
+  if [[ -z "${DATABASE_PASSWORD}" ]]; then
+    PASSWD=$(jq .pg.passwd pgconfig.json | sed "y/\"/'/")
+  else
+    PASSWD=$DATABASE_PASSWORD
+  fi
 
-case $OSTYPE in
- darwin*) echo "Creating Default user $USER..." ;
- psql -U postgres -c "CREATE USER $USER WITH PASSWORD '$PASSWD'" ;
- psql postgres -v dbname=$DATABASE -v user=$USER -v passwd=$PASSWD -f ./explorerpg.sql ;
- psql postgres -v dbname=$DATABASE -v user=$USER -v passwd=$PASSWD -f ./updatepg.sql ;;
- linux*) echo "Creating Default user..." ;
- sudo -u postgres psql -U postgres -c "CREATE USER $USER WITH PASSWORD '$PASSWD'" ;
- sudo -u postgres psql -v dbname=$DATABASE -v user=$USER -v passwd=$PASSWD -f ./explorerpg.sql ;
- sudo -u postgres psql -v dbname=$DATABASE -v user=$USER -v passwd=$PASSWD -f ./updatepg.sql ;;
-esac
+  echo "USER=${USER}"
+  echo "DATABASE=${DATABASE}"
+  echo "PASSWD=${PASSWD}"
+
+  case $OSTYPE in
+   darwin*)
+   echo "Creating Default user $USER..." ;
+   psql -U postgres -c "CREATE USER $USER WITH PASSWORD '$PASSWD'" ;
+   psql postgres -v dbname=$DATABASE -v user=$USER -v passwd=$PASSWD -f ./explorerpg.sql ;
+   psql postgres -v dbname=$DATABASE -v user=$USER -v passwd=$PASSWD -f ./updatepg.sql ;;
+
+   linux*)
+   WHOAMI=`whoami`
+   if [ "${WHOAMI}" != "postgres" ]; then
+     echo "Creating Default user..." ;
+     sudo -u postgres psql -U postgres -c "CREATE USER $USER WITH PASSWORD '$PASSWD'" ;
+     sudo -u postgres psql -v dbname=$DATABASE -v user=$USER -v passwd=$PASSWD -f ./explorerpg.sql ;
+     sudo -u postgres psql -v dbname=$DATABASE -v user=$USER -v passwd=$PASSWD -f ./updatepg.sql
+   else
+     echo "Creating Default user..." ;
+     psql -U postgres -c "CREATE USER $USER WITH PASSWORD '$PASSWD'" ;
+     psql -v dbname=$DATABASE -v user=$USER -v passwd=$PASSWD -f ./explorerpg.sql ;
+     psql -v dbname=$DATABASE -v user=$USER -v passwd=$PASSWD -f ./updatepg.sql
+   fi
+   ;;
+  esac
+
+  touch /${PGDATA}/conf.done
+fi

--- a/app/persistence/postgreSQL/db/explorerpg.sql
+++ b/app/persistence/postgreSQL/db/explorerpg.sql
@@ -2,7 +2,7 @@
 --    SPDX-License-Identifier: Apache-2.0
 --
 
-CREATE USER :user WITH PASSWORD :passwd;
+-- CREATE USER :user WITH PASSWORD :passwd;
 DROP DATABASE IF EXISTS :dbname;
 CREATE DATABASE :dbname owner :user;
 \c :dbname;


### PR DESCRIPTION
... by using Postgre entrypoint feature as described here : https://hub.docker.com/_/postgres/ (How to extend this image)

Then I'm able to run Hyperledger Explorer as follow : 

```
version: '2.1'

networks:
  mynetwork.com:
    name: mynetwork.com

services:

  explorerdb.mynetwork.com:
    image: mffrench/explorer-db:0.3.5.1
    container_name: explorerdb.mynetwork.com
    hostname: explorerdb.mynetwork.com
    environment:
      - DATABASE_DATABASE=fabricexplorer
      - DATABASE_USERNAME=hppoc
      - DATABASE_PASSWORD=password
    command: bash -c "cp /opt/createdb.sh /docker-entrypoint-initdb.d && /docker-entrypoint.sh postgres"
    networks:
      - mynetwork.com

  explorer.mynetwork.com:
    image: mffrench/explorer:0.3.5.1
    container_name: explorer.mynetwork.com
    hostname: explorer.mynetwork.com
    environment:
      - DATABASE_HOST=explorerdb.mynetwork.com
      - DATABASE_USERNAME=hppoc
      - DATABASE_PASSWD=password
    volumes:
      - ./explorer-config/config.json:/opt/explorer/app/platform/fabric/config.json
      - ./crypto-config:/tmp/crypto
    command: sh -c "sleep 16 && node /opt/explorer/main.js && tail -f /dev/null"
    ports:
      - 8090:8080
    networks:
     - mynetwork.com
```