### PR TITLE
Update deploy_explorer.sh

### DIFF
--- a/deploy_explorer.sh
+++ b/deploy_explorer.sh
@@ -194,7 +194,7 @@ function deploy_run_explorer(){
 		-e ADMIN_SECRET="adminpw" \
 		-v $network_config_file:/opt/explorer/app/platform/fabric/config.json \
 		-v $network_crypto_base_path:/tmp/crypto \
-		-p 8090:8080 \
+		-p 8080:8080 \
 		$fabric_explorer_tag
 }
 


### PR DESCRIPTION
For docker deployment exposed port is 8090 instead of mentioned 8080.

Change in README or in deploy_explorer.sh is needed.

I've updated deploy_run_explorer function to 8080:8080 so internal and external port is the same and it's the one used in documentation.