### PR TITLE
BE-685 Implement option to configure TLS connection to Postgresql

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,8 @@ Connect to the PostgreSQL database and run DB status commands:
 - `\l`  View created fabricexplorer database.
 - `\d`  View created tables.
 
+If your Postgresql configured with TLS, read link [how to configure connection to Postgresql with TLS](./app/persistence/CONFIGURE-TLS-CONNECTION-TO-POSTGRESQL.md) 
+
 <a name="Authorization-Configuration" />
 
 # 5.1 Authorization Configuration    <!-- do not remove this comment, ensure there is a blank line before each heading -->

--- a/app/persistence/CONFIGURE-TLS-CONNECTION-TO-POSTGRESQL.md
+++ b/app/persistence/CONFIGURE-TLS-CONNECTION-TO-POSTGRESQL.md
@@ -1,0 +1,16 @@
+
+<!-- (SPDX-License-Identifier: CC-BY-4.0) -->  <!-- Ensure there is a newline before, and after, this line -->
+
+# TLS connection to Postgresql
+
+In order to configure TLS connection to Postgresql take next steps:
+
+- [Optional] pass environment variable `DATABASE_CERTS_PATH`, default is `/opt/explorer/db-certs` 
+
+- put certificates into folder specified by `DATABASE_CERTS_PATH`. There should be three files:
+
+    - `client-cert.pem`
+    - `client-key.pem`
+    - `server-ca.pem`
+    
+- pass environment variable `DATABASE_SSL_ENABLED=true`


### PR DESCRIPTION
hyperledger explorer does not support TLS connection to Postgresql, see https://jira.hyperledger.org/browse/BE-685

This PR  introduces new env variables: DATABASE_SSL_ENABLED (default is false), DATABASE_CERTS_PATH (default is EXPLORER_APP_PATH}/db-certs, and configures TLS connection by provided certificates in folder db-certs