### PR TITLE
BE-730 Multi profile support 

### DIFF
--- a/app/middleware/auth-check.js
+++ b/app/middleware/auth-check.js
@@ -26,9 +26,10 @@ module.exports = (req, res, next) => {
 			return res.status(401).end();
 		}
 
-		const userId = decoded.sub;
+		const userId = decoded.user;
 
 		req.userId = userId;
+		req.network = decoded.network;
 
 		// TODO: check if a user exists, otherwise error
 

--- a/app/passport/local-login.js
+++ b/app/passport/local-login.js
@@ -35,7 +35,8 @@ const strategy = function(platform) {
 			const userInfo = await proxy.authenticate(reqUser);
 
 			const payload = {
-				sub: userInfo.user
+				user: userInfo.user,
+				network: userInfo.network
 			};
 
 			if (userInfo && !userInfo.authenticated) {
@@ -53,7 +54,8 @@ const strategy = function(platform) {
 			// @ts-check
 			const data = {
 				message: 'logged in',
-				name: userData.user
+				name: userData.user,
+				network: userData.network
 			};
 
 			return done(null, token, data);

--- a/app/persistence/fabric/MetricService.js
+++ b/app/persistence/fabric/MetricService.js
@@ -23,9 +23,9 @@ class MetricService {
 	 * @returns
 	 * @memberof MetricService
 	 */
-	getChaincodeCount(channel_genesis_hash) {
+	getChaincodeCount(network_name, channel_genesis_hash) {
 		return this.sql.getRowsBySQlCase(
-			`select count(1) c from chaincodes where channel_genesis_hash='${channel_genesis_hash}' `
+			`select count(1) c from chaincodes where channel_genesis_hash='${channel_genesis_hash}' and network_name='${network_name}' `
 		);
 	}
 
@@ -36,9 +36,9 @@ class MetricService {
 	 * @returns
 	 * @memberof MetricService
 	 */
-	getPeerlistCount(channel_genesis_hash) {
+	getPeerlistCount(network_name, channel_genesis_hash) {
 		return this.sql.getRowsBySQlCase(
-			`select count(1) c from peer where channel_genesis_hash='${channel_genesis_hash}' and peer_type='PEER' `
+			`select count(1) c from peer where channel_genesis_hash='${channel_genesis_hash}' and peer_type='PEER' and network_name='${network_name}' `
 		);
 	}
 
@@ -49,9 +49,9 @@ class MetricService {
 	 * @returns
 	 * @memberof MetricService
 	 */
-	getTxCount(channel_genesis_hash) {
+	getTxCount(network_name, channel_genesis_hash) {
 		return this.sql.getRowsBySQlCase(
-			`select count(1) c from transactions where channel_genesis_hash='${channel_genesis_hash}'`
+			`select count(1) c from transactions where channel_genesis_hash='${channel_genesis_hash}' and network_name='${network_name}' `
 		);
 	}
 
@@ -62,9 +62,9 @@ class MetricService {
 	 * @returns
 	 * @memberof MetricService
 	 */
-	getBlockCount(channel_genesis_hash) {
+	getBlockCount(network_name, channel_genesis_hash) {
 		return this.sql.getRowsBySQlCase(
-			`select count(1) c from blocks where channel_genesis_hash='${channel_genesis_hash}'`
+			`select count(1) c from blocks where channel_genesis_hash='${channel_genesis_hash}' and network_name='${network_name}' `
 		);
 	}
 
@@ -75,12 +75,12 @@ class MetricService {
 	 * @returns
 	 * @memberof MetricService
 	 */
-	async getPeerData(channel_genesis_hash) {
+	async getPeerData(network_name, channel_genesis_hash) {
 		const peerArray = [];
 		const c1 = await this.sql
 			.getRowsBySQlNoCondition(`select channel.name as channelName,c.requests as requests,c.channel_genesis_hash as channel_genesis_hash ,
     c.server_hostname as server_hostname, c.mspid as mspid, c.peer_type as peer_type  from peer as c inner join  channel on
-    c.channel_genesis_hash=channel.channel_genesis_hash where c.channel_genesis_hash='${channel_genesis_hash}'`);
+    c.channel_genesis_hash=channel.channel_genesis_hash where c.channel_genesis_hash='${channel_genesis_hash}' and c.network_name='${network_name}' `);
 		for (let i = 0, len = c1.length; i < len; i++) {
 			const item = c1[i];
 			peerArray.push({
@@ -101,10 +101,10 @@ class MetricService {
 	 * @returns
 	 * @memberof MetricService
 	 */
-	async getOrdererData() {
+	async getOrdererData(network_name) {
 		const ordererArray = [];
 		const c1 = await this.sql.getRowsBySQlNoCondition(
-			'select c.requests as requests,c.server_hostname as server_hostname,c.channel_genesis_hash as channel_genesis_hash from orderer c'
+			`select c.requests as requests,c.server_hostname as server_hostname,c.channel_genesis_hash as channel_genesis_hash from orderer c where network_name='${network_name}' `
 		);
 		for (let i = 0, len = c1.length; i < len; i++) {
 			const item = c1[i];
@@ -124,11 +124,11 @@ class MetricService {
 	 * @returns
 	 * @memberof MetricService
 	 */
-	async getTxPerChaincodeGenerate(channel_genesis_hash) {
+	async getTxPerChaincodeGenerate(network_name, channel_genesis_hash) {
 		const txArray = [];
 		const c = await this.sql
 			.getRowsBySQlNoCondition(`select  c.name as chaincodename,channel.name as channelname ,c.version as version,c.channel_genesis_hash
-       as channel_genesis_hash,c.path as path ,txcount  as c from chaincodes as c inner join channel on c.channel_genesis_hash=channel.channel_genesis_hash where  c.channel_genesis_hash='${channel_genesis_hash}' `);
+       as channel_genesis_hash,c.path as path ,txcount  as c from chaincodes as c inner join channel on c.channel_genesis_hash=channel.channel_genesis_hash where  c.channel_genesis_hash='${channel_genesis_hash}' and  c.network_name='${network_name}' `);
 		if (c) {
 			c.forEach((item, index) => {
 				logger.debug(' item ------------> ', item);
@@ -152,10 +152,10 @@ class MetricService {
 	 * @returns
 	 * @memberof MetricService
 	 */
-	async getOrgsData(channel_genesis_hash) {
+	async getOrgsData(network_name, channel_genesis_hash) {
 		const orgs = [];
 		const rows = await this.sql.getRowsBySQlNoCondition(
-			`select distinct on (mspid) mspid from peer  where channel_genesis_hash='${channel_genesis_hash}'`
+			`select distinct on (mspid) mspid from peer  where channel_genesis_hash='${channel_genesis_hash}' and network_name='${network_name}'`
 		);
 		for (let i = 0, len = rows.length; i < len; i++) {
 			orgs.push(rows[i].mspid);
@@ -171,9 +171,12 @@ class MetricService {
 	 * @returns
 	 * @memberof MetricService
 	 */
-	async getTxPerChaincode(channel_genesis_hash, cb) {
+	async getTxPerChaincode(network_name, channel_genesis_hash, cb) {
 		try {
-			const txArray = await this.getTxPerChaincodeGenerate(channel_genesis_hash);
+			const txArray = await this.getTxPerChaincodeGenerate(
+				network_name,
+				channel_genesis_hash
+			);
 			return cb(txArray);
 		} catch (err) {
 			logger.error(err);
@@ -188,22 +191,28 @@ class MetricService {
 	 * @returns
 	 * @memberof MetricService
 	 */
-	async getStatusGenerate(channel_genesis_hash) {
-		let chaincodeCount = await this.getChaincodeCount(channel_genesis_hash);
+	async getStatusGenerate(network_name, channel_genesis_hash) {
+		let chaincodeCount = await this.getChaincodeCount(
+			network_name,
+			channel_genesis_hash
+		);
 		if (!chaincodeCount) {
 			chaincodeCount = 0;
 		}
-		let txCount = await this.getTxCount(channel_genesis_hash);
+		let txCount = await this.getTxCount(network_name, channel_genesis_hash);
 		if (!txCount) {
 			txCount = 0;
 		}
 		txCount.c = txCount.c ? txCount.c : 0;
-		let blockCount = await this.getBlockCount(channel_genesis_hash);
+		let blockCount = await this.getBlockCount(network_name, channel_genesis_hash);
 		if (!blockCount) {
 			blockCount = 0;
 		}
 		blockCount.c = blockCount.c ? blockCount.c : 0;
-		let peerCount = await this.getPeerlistCount(channel_genesis_hash);
+		let peerCount = await this.getPeerlistCount(
+			network_name,
+			channel_genesis_hash
+		);
 		if (!peerCount) {
 			peerCount = 0;
 		}
@@ -224,9 +233,12 @@ class MetricService {
 	 * @returns
 	 * @memberof MetricService
 	 */
-	async getStatus(channel_genesis_hash, cb) {
+	async getStatus(network_name, channel_genesis_hash, cb) {
 		try {
-			const data = await this.getStatusGenerate(channel_genesis_hash);
+			const data = await this.getStatusGenerate(
+				network_name,
+				channel_genesis_hash
+			);
 			return cb(data);
 		} catch (err) {
 			logger.error(err);
@@ -242,9 +254,9 @@ class MetricService {
 	 * @returns
 	 * @memberof MetricService
 	 */
-	async getPeerList(channel_genesis_hash, cb) {
+	async getPeerList(network_name, channel_genesis_hash, cb) {
 		try {
-			const peerArray = await this.getPeerData(channel_genesis_hash);
+			const peerArray = await this.getPeerData(network_name, channel_genesis_hash);
 			if (cb) {
 				return cb(peerArray);
 			}
@@ -262,9 +274,9 @@ class MetricService {
 	 * @returns
 	 * @memberof MetricService
 	 */
-	async getOrdererList(cb) {
+	async getOrdererList(network_name, cb) {
 		try {
-			const ordererArray = await this.getOrdererData();
+			const ordererArray = await this.getOrdererData(network_name);
 			return cb(ordererArray);
 		} catch (err) {
 			logger.error(err);
@@ -280,7 +292,7 @@ class MetricService {
 	 * @returns
 	 * @memberof MetricService
 	 */
-	getTxByMinute(channel_genesis_hash, hours) {
+	getTxByMinute(network_name, channel_genesis_hash, hours) {
 		const sqlPerMinute = ` with minutes as (
             select generate_series(
               date_trunc('min', now()) - '${hours}hour'::interval,
@@ -292,7 +304,7 @@ class MetricService {
             minutes.datetime,
             count(createdt)
           from minutes
-          left join TRANSACTIONS on date_trunc('min', TRANSACTIONS.createdt) = minutes.datetime and channel_genesis_hash ='${channel_genesis_hash}'
+          left join TRANSACTIONS on date_trunc('min', TRANSACTIONS.createdt) = minutes.datetime and channel_genesis_hash ='${channel_genesis_hash}' and network_name='${network_name}'
           group by 1
           order by 1 `;
 
@@ -307,7 +319,7 @@ class MetricService {
 	 * @returns
 	 * @memberof MetricService
 	 */
-	getTxByHour(channel_genesis_hash, day) {
+	getTxByHour(network_name, channel_genesis_hash, day) {
 		const sqlPerHour = ` with hours as (
             select generate_series(
               date_trunc('hour', now()) - '${day}day'::interval,
@@ -319,7 +331,7 @@ class MetricService {
             hours.datetime,
             count(createdt)
           from hours
-          left join TRANSACTIONS on date_trunc('hour', TRANSACTIONS.createdt) = hours.datetime and channel_genesis_hash ='${channel_genesis_hash}'
+          left join TRANSACTIONS on date_trunc('hour', TRANSACTIONS.createdt) = hours.datetime and channel_genesis_hash ='${channel_genesis_hash}' and network_name='${network_name}'
           group by 1
           order by 1 `;
 
@@ -334,7 +346,7 @@ class MetricService {
 	 * @returns
 	 * @memberof MetricService
 	 */
-	getTxByDay(channel_genesis_hash, days) {
+	getTxByDay(network_name, channel_genesis_hash, days) {
 		const sqlPerDay = ` with days as (
             select generate_series(
               date_trunc('day', now()) - '${days}day'::interval,
@@ -346,7 +358,7 @@ class MetricService {
             days.datetime,
             count(createdt)
           from days
-          left join TRANSACTIONS on date_trunc('day', TRANSACTIONS.createdt) =days.datetime and channel_genesis_hash ='${channel_genesis_hash}'
+          left join TRANSACTIONS on date_trunc('day', TRANSACTIONS.createdt) =days.datetime and channel_genesis_hash ='${channel_genesis_hash}' and network_name='${network_name}'
           group by 1
           order by 1 `;
 
@@ -361,7 +373,7 @@ class MetricService {
 	 * @returns
 	 * @memberof MetricService
 	 */
-	getTxByWeek(channel_genesis_hash, weeks) {
+	getTxByWeek(network_name, channel_genesis_hash, weeks) {
 		const sqlPerWeek = ` with weeks as (
             select generate_series(
               date_trunc('week', now()) - '${weeks}week'::interval,
@@ -373,7 +385,7 @@ class MetricService {
             weeks.datetime,
             count(createdt)
           from weeks
-          left join TRANSACTIONS on date_trunc('week', TRANSACTIONS.createdt) =weeks.datetime and channel_genesis_hash ='${channel_genesis_hash}'
+          left join TRANSACTIONS on date_trunc('week', TRANSACTIONS.createdt) =weeks.datetime and channel_genesis_hash ='${channel_genesis_hash}' and network_name='${network_name}'
           group by 1
           order by 1 `;
 
@@ -388,7 +400,7 @@ class MetricService {
 	 * @returns
 	 * @memberof MetricService
 	 */
-	getTxByMonth(channel_genesis_hash, months) {
+	getTxByMonth(network_name, channel_genesis_hash, months) {
 		const sqlPerMonth = ` with months as (
             select generate_series(
               date_trunc('month', now()) - '${months}month'::interval,
@@ -401,7 +413,7 @@ class MetricService {
             months.datetime,
             count(createdt)
           from months
-          left join TRANSACTIONS on date_trunc('month', TRANSACTIONS.createdt) =months.datetime  and channel_genesis_hash ='${channel_genesis_hash}'
+          left join TRANSACTIONS on date_trunc('month', TRANSACTIONS.createdt) =months.datetime  and channel_genesis_hash ='${channel_genesis_hash}' and network_name='${network_name}'
           group by 1
           order by 1 `;
 
@@ -416,7 +428,7 @@ class MetricService {
 	 * @returns
 	 * @memberof MetricService
 	 */
-	getTxByYear(channel_genesis_hash, years) {
+	getTxByYear(network_name, channel_genesis_hash, years) {
 		const sqlPerYear = ` with years as (
             select generate_series(
               date_trunc('year', now()) - '${years}year'::interval,
@@ -428,7 +440,7 @@ class MetricService {
             years.year,
             count(createdt)
           from years
-          left join TRANSACTIONS on date_trunc('year', TRANSACTIONS.createdt) =years.year and channel_genesis_hash ='${channel_genesis_hash}'
+          left join TRANSACTIONS on date_trunc('year', TRANSACTIONS.createdt) =years.year and channel_genesis_hash ='${channel_genesis_hash}' and network_name='${network_name}'
           group by 1
           order by 1 `;
 
@@ -444,7 +456,7 @@ class MetricService {
 	 * @returns
 	 * @memberof MetricService
 	 */
-	getBlocksByMinute(channel_genesis_hash, hours) {
+	getBlocksByMinute(network_name, channel_genesis_hash, hours) {
 		const sqlPerMinute = ` with minutes as (
             select generate_series(
               date_trunc('min', now()) - '${hours} hour'::interval,
@@ -456,7 +468,7 @@ class MetricService {
             minutes.datetime,
             count(createdt)
           from minutes
-          left join BLOCKS on date_trunc('min', BLOCKS.createdt) = minutes.datetime and channel_genesis_hash ='${channel_genesis_hash}'
+          left join BLOCKS on date_trunc('min', BLOCKS.createdt) = minutes.datetime and channel_genesis_hash ='${channel_genesis_hash}' and network_name='${network_name}'
           group by 1
           order by 1  `;
 
@@ -471,7 +483,7 @@ class MetricService {
 	 * @returns
 	 * @memberof MetricService
 	 */
-	getBlocksByHour(channel_genesis_hash, days) {
+	getBlocksByHour(network_name, channel_genesis_hash, days) {
 		const sqlPerHour = ` with hours as (
             select generate_series(
               date_trunc('hour', now()) - '${days}day'::interval,
@@ -483,7 +495,7 @@ class MetricService {
             hours.datetime,
             count(createdt)
           from hours
-          left join BLOCKS on date_trunc('hour', BLOCKS.createdt) = hours.datetime and channel_genesis_hash ='${channel_genesis_hash}'
+          left join BLOCKS on date_trunc('hour', BLOCKS.createdt) = hours.datetime and channel_genesis_hash ='${channel_genesis_hash}' and network_name='${network_name}'
           group by 1
           order by 1 `;
 
@@ -498,7 +510,7 @@ class MetricService {
 	 * @returns
 	 * @memberof MetricService
 	 */
-	getBlocksByDay(channel_genesis_hash, days) {
+	getBlocksByDay(network_name, channel_genesis_hash, days) {
 		const sqlPerDay = `  with days as (
             select generate_series(
               date_trunc('day', now()) - '${days}day'::interval,
@@ -510,7 +522,7 @@ class MetricService {
             days.datetime,
             count(createdt)
           from days
-          left join BLOCKS on date_trunc('day', BLOCKS.createdt) =days.datetime and channel_genesis_hash ='${channel_genesis_hash}'
+          left join BLOCKS on date_trunc('day', BLOCKS.createdt) =days.datetime and channel_genesis_hash ='${channel_genesis_hash}' and network_name='${network_name}'
           group by 1
           order by 1 `;
 
@@ -525,7 +537,7 @@ class MetricService {
 	 * @returns
 	 * @memberof MetricService
 	 */
-	getBlocksByWeek(channel_genesis_hash, weeks) {
+	getBlocksByWeek(network_name, channel_genesis_hash, weeks) {
 		const sqlPerWeek = ` with weeks as (
             select generate_series(
               date_trunc('week', now()) - '${weeks}week'::interval,
@@ -537,7 +549,7 @@ class MetricService {
             weeks.datetime,
             count(createdt)
           from weeks
-          left join BLOCKS on date_trunc('week', BLOCKS.createdt) =weeks.datetime and channel_genesis_hash ='${channel_genesis_hash}'
+          left join BLOCKS on date_trunc('week', BLOCKS.createdt) =weeks.datetime and channel_genesis_hash ='${channel_genesis_hash}' and network_name='${network_name}'
           group by 1
           order by 1 `;
 
@@ -552,7 +564,7 @@ class MetricService {
 	 * @returns
 	 * @memberof MetricService
 	 */
-	getBlocksByMonth(channel_genesis_hash, months) {
+	getBlocksByMonth(network_name, channel_genesis_hash, months) {
 		const sqlPerMonth = `  with months as (
             select generate_series(
               date_trunc('month', now()) - '${months}month'::interval,
@@ -564,7 +576,7 @@ class MetricService {
             months.datetime,
             count(createdt)
           from months
-          left join BLOCKS on date_trunc('month', BLOCKS.createdt) =months.datetime and channel_genesis_hash  ='${channel_genesis_hash}'
+          left join BLOCKS on date_trunc('month', BLOCKS.createdt) =months.datetime and channel_genesis_hash  ='${channel_genesis_hash}' and network_name='${network_name}'
           group by 1
           order by 1 `;
 
@@ -579,7 +591,7 @@ class MetricService {
 	 * @returns
 	 * @memberof MetricService
 	 */
-	getBlocksByYear(channel_genesis_hash, years) {
+	getBlocksByYear(network_name, channel_genesis_hash, years) {
 		const sqlPerYear = ` with years as (
             select generate_series(
               date_trunc('year', now()) - '${years}year'::interval,
@@ -591,7 +603,7 @@ class MetricService {
             years.year,
             count(createdt)
           from years
-          left join BLOCKS on date_trunc('year', BLOCKS.createdt) =years.year and channel_genesis_hash  ='${channel_genesis_hash}'
+          left join BLOCKS on date_trunc('year', BLOCKS.createdt) =years.year and channel_genesis_hash  ='${channel_genesis_hash}' and network_name='${network_name}'
           group by 1
           order by 1 `;
 
@@ -605,10 +617,10 @@ class MetricService {
 	 * @returns
 	 * @memberof MetricService
 	 */
-	getTxByOrgs(channel_genesis_hash) {
+	getTxByOrgs(network_name, channel_genesis_hash) {
 		const sqlPerOrg = ` select count(creator_msp_id), creator_msp_id
       from transactions
-      where channel_genesis_hash ='${channel_genesis_hash}'
+      where channel_genesis_hash ='${channel_genesis_hash}' and network_name='${network_name}'
       group by  creator_msp_id`;
 
 		return this.sql.getRowsBySQlQuery(sqlPerOrg);
@@ -622,9 +634,9 @@ class MetricService {
 	 * @returns
 	 * @memberof MetricService
 	 */
-	async findMissingBlockNumber(channel_genesis_hash, maxHeight) {
+	async findMissingBlockNumber(network_name, channel_genesis_hash, maxHeight) {
 		const sqlQuery = `SELECT s.id AS missing_id
-    FROM generate_series(0, ${maxHeight}) s(id) WHERE NOT EXISTS (SELECT 1 FROM blocks WHERE blocknum = s.id and channel_genesis_hash ='${channel_genesis_hash}' )`;
+    FROM generate_series(0, ${maxHeight}) s(id) WHERE NOT EXISTS (SELECT 1 FROM blocks WHERE blocknum = s.id and channel_genesis_hash ='${channel_genesis_hash}' and network_name='${network_name}' )`;
 
 		return this.sql.getRowsBySQlQuery(sqlQuery);
 	}

--- a/app/persistence/fabric/postgreSQL/db/explorerpg.sql
+++ b/app/persistence/fabric/postgreSQL/db/explorerpg.sql
@@ -25,7 +25,8 @@ CREATE TABLE blocks
   prev_blockhash character varying(256) DEFAULT NULL,
   blockhash character varying(256) DEFAULT NULL,
   channel_genesis_hash character varying(256) DEFAULT NULL,
-  blksize integer DEFAULT NULL
+  blksize integer DEFAULT NULL,
+  network_name varchar(255)
 );
 
 ALTER table blocks owner to :user;
@@ -43,7 +44,8 @@ CREATE TABLE chaincodes
   path character varying(255) DEFAULT NULL,
   channel_genesis_hash character varying(256) DEFAULT NULL,
   txcount integer DEFAULT 0,
-  createdt Timestamp DEFAULT NULL
+  createdt Timestamp DEFAULT NULL,
+  network_name varchar(255)
 );
 
 ALTER table chaincodes owner to :user;
@@ -61,7 +63,8 @@ CREATE TABLE peer_ref_chaincode
   chaincodeid varchar(64) DEFAULT NULL,
   cc_version varchar(64) DEFAULT NULL,
   channelid character varying(256) DEFAULT NULL,
-  createdt Timestamp DEFAULT NULL
+  createdt Timestamp DEFAULT NULL,
+  network_name varchar(255)
 );
 ALTER table peer_ref_chaincode owner to :user;
 
@@ -84,7 +87,8 @@ CREATE TABLE channel
   channel_config bytea default NULL,
   channel_block bytea DEFAULT NULL,
   channel_tx bytea DEFAULT NULL,
-  channel_version character varying(128) DEFAULT NULL
+  channel_version character varying(128) DEFAULT NULL,
+  network_name varchar(255)
 );
 
 ALTER table channel owner to :user;
@@ -106,7 +110,8 @@ CREATE TABLE peer
   events varchar(64) DEFAULT NULL,
   server_hostname varchar(64) DEFAULT NULL,
   createdt timestamp DEFAULT NULL,
-  peer_type character varying(64) DEFAULT NULL
+  peer_type character varying(64) DEFAULT NULL,
+  network_name varchar(255)
 );
 ALTER table peer owner to :user;
 -- ---------------------------
@@ -120,7 +125,8 @@ CREATE TABLE peer_ref_channel
   createdt Timestamp DEFAULT NULL,
   peerid varchar(64),
   channelid character varying(256),
-  peer_type character varying(64) DEFAULT NULL
+  peer_type character varying(64) DEFAULT NULL,
+  network_name varchar(255)
 );
 ALTER table peer_ref_channel owner to :user;
 
@@ -137,7 +143,8 @@ CREATE TABLE orderer
   id SERIAL PRIMARY KEY,
   requests varchar(64) DEFAULT NULL,
   server_hostname varchar(64) DEFAULT NULL,
-  createdt timestamp DEFAULT NULL
+  createdt timestamp DEFAULT NULL,
+  network_name varchar(255)
 );
 ALTER table orderer owner to :user;
 
@@ -170,7 +177,8 @@ CREATE TABLE transactions
   tx_response character varying DEFAULT NULL,
   payload_proposal_hash character varying DEFAULT NULL,
   endorser_id_bytes character varying DEFAULT NULL,
-  endorser_signature character varying DEFAULT NULL
+  endorser_signature character varying DEFAULT NULL,
+  network_name varchar(255)
 );
 
 ALTER table transactions owner to :user;

--- a/app/persistence/postgreSQL/PgService.js
+++ b/app/persistence/postgreSQL/PgService.js
@@ -72,9 +72,7 @@ class PgService {
 		}
 
 		// don't log password
-		const connectionString = `postgres://${this.pgconfig.username}:******@${
-			this.pgconfig.host
-		}:${this.pgconfig.port}/${this.pgconfig.database}`;
+		const connectionString = `postgres://${this.pgconfig.username}:******@${this.pgconfig.host}:${this.pgconfig.port}/${this.pgconfig.database}`;
 
 		logger.info(`connecting to Postgresql ${connectionString}`);
 

--- a/app/platform/fabric/FabricClient.js
+++ b/app/platform/fabric/FabricClient.js
@@ -32,7 +32,8 @@ class FabricClient {
 	 * @param {*} client_name
 	 * @memberof FabricClient
 	 */
-	constructor(client_name) {
+	constructor(network_name, client_name) {
+		this.network_name = network_name;
 		this.client_name = client_name;
 		this.hfc_client = null;
 		this.fabricGateway = null;
@@ -213,7 +214,7 @@ class FabricClient {
 		const default_peer_name = defaultPeerConfig.name;
 		const channels = await persistence
 			.getCrudService()
-			.getChannelsInfo(default_peer_name);
+			.getChannelsInfo(this.network_name, default_peer_name);
 
 		const default_channel_name = fabricConfig.getDefaultChannel();
 
@@ -225,7 +226,7 @@ class FabricClient {
 			this.setChannelGenHash(channel.channelname, channel.channel_genesis_hash);
 			const nodes = await persistence
 				.getMetricService()
-				.getPeerList(channel.channel_genesis_hash);
+				.getPeerList(this.network_name, channel.channel_genesis_hash);
 			let newchannel;
 			try {
 				newchannel = this.hfc_client.getChannel(channel.channelname);

--- a/app/platform/fabric/Proxy.js
+++ b/app/platform/fabric/Proxy.js
@@ -74,8 +74,10 @@ class Proxy {
 	 * @returns
 	 * @memberof Proxy
 	 */
-	async getCurrentChannel() {
-		const client = await this.platform.getClient();
+	async getCurrentChannel(network_name) {
+		logger.debug('getCurrentChannel: network_name', network_name);
+
+		const client = await this.platform.getClient(network_name);
 		const channel = client.getDefaultChannel();
 		const channel_genesis_hash = client.getChannelGenHash(channel.getName());
 		let respose;
@@ -101,12 +103,12 @@ class Proxy {
 	 * @returns
 	 * @memberof Proxy
 	 */
-	async getPeersStatus(channel_genesis_hash) {
-		const client = await this.platform.getClient();
+	async getPeersStatus(network_name, channel_genesis_hash) {
+		const client = await this.platform.getClient(network_name);
 		const channel = client.getDefaultChannel();
 		const nodes = await this.persistence
 			.getMetricService()
-			.getPeerList(channel_genesis_hash);
+			.getPeerList(network_name, channel_genesis_hash);
 		let discover_results;
 		if (client.status) {
 			try {
@@ -161,8 +163,8 @@ class Proxy {
 	 * @returns
 	 * @memberof Proxy
 	 */
-	async changeChannel(channel_genesis_hash) {
-		const client = this.platform.getClient();
+	async changeChannel(network_name, channel_genesis_hash) {
+		const client = this.platform.getClient(network_name);
 		const respose = client.setDefaultChannelByHash(channel_genesis_hash);
 		logger.debug('changeChannel >> %s', respose);
 		return respose;
@@ -174,11 +176,11 @@ class Proxy {
 	 * @returns
 	 * @memberof Proxy
 	 */
-	async getChannelsInfo() {
-		const client = this.platform.getClient();
+	async getChannelsInfo(network_name) {
+		const client = this.platform.getClient(network_name);
 		const channels = await this.persistence
 			.getCrudService()
-			.getChannelsInfo(client.getDefaultPeer());
+			.getChannelsInfo(network_name, client.getDefaultPeer());
 		const currentchannels = [];
 		for (const channel of channels) {
 			const channel_genesis_hash = client.getChannelGenHash(channel.channelname);
@@ -200,13 +202,13 @@ class Proxy {
 	 * @returns
 	 * @memberof Proxy
 	 */
-	async getTxByOrgs(channel_genesis_hash) {
+	async getTxByOrgs(network_name, channel_genesis_hash) {
 		const rows = await this.persistence
 			.getMetricService()
-			.getTxByOrgs(channel_genesis_hash);
+			.getTxByOrgs(network_name, channel_genesis_hash);
 		const organizations = await this.persistence
 			.getMetricService()
-			.getOrgsData(channel_genesis_hash);
+			.getOrgsData(network_name, channel_genesis_hash);
 
 		for (const organization of rows) {
 			const index = organizations.indexOf(organization.creator_msp_id);
@@ -231,8 +233,8 @@ class Proxy {
 	 * @returns
 	 * @memberof Proxy
 	 */
-	async getBlockByNumber(channel_genesis_hash, number) {
-		const client = this.platform.getClient();
+	async getBlockByNumber(network_name, channel_genesis_hash, number) {
+		const client = this.platform.getClient(network_name);
 		const channel = client.getChannelByHash(channel_genesis_hash);
 
 		const block = channel.queryBlock(
@@ -265,20 +267,18 @@ class Proxy {
 	 * @returns
 	 * @memberof Proxy
 	 */
-	async getChannels() {
-		const client = this.platform.getClient();
+	async getChannels(network_name) {
+		const client = this.platform.getClient(network_name);
 		const client_channels = client.getChannelNames();
 		const channels = await this.persistence
 			.getCrudService()
-			.getChannelsInfo(client.getDefaultPeer());
+			.getChannelsInfo(network_name, client.getDefaultPeer());
 		const respose = [];
 
 		for (let i = 0; i < channels.length; i++) {
 			const index = client_channels.indexOf(channels[i].channelname);
 			if (!(index > -1)) {
-				await this.platform
-					.getClient()
-					.initializeNewChannel(channels[i].channelname);
+				await client.initializeNewChannel(channels[i].channelname);
 			}
 			respose.push(channels[i].channelname);
 		}
@@ -326,9 +326,7 @@ class Proxy {
 		if (fabric_const.NOTITY_TYPE_NEWCHANNEL === msg.notify_type) {
 			// Initialize new channel instance in parent
 			if (msg.network_name && msg.client_name) {
-				const client = this.platform.networks
-					.get(msg.network_name)
-					.get(msg.client_name);
+				const client = this.platform.getClient(msg.network_name);
 				if (msg.channel_name) {
 					client.initializeNewChannel(msg.channel_name);
 				} else {
@@ -347,9 +345,7 @@ class Proxy {
 		) {
 			// Update channel details in parent
 			if (msg.network_name && msg.client_name) {
-				const client = this.platform.networks
-					.get(msg.network_name)
-					.get(msg.client_name);
+				const client = this.platform.getClient(msg.network_name);
 				if (msg.channel_name) {
 					client.initializeChannelFromDiscover(msg.channel_name);
 				} else {

--- a/app/platform/fabric/Proxy.js
+++ b/app/platform/fabric/Proxy.js
@@ -236,12 +236,17 @@ class Proxy {
 	async getBlockByNumber(network_name, channel_genesis_hash, number) {
 		const client = this.platform.getClient(network_name);
 		const channel = client.getChannelByHash(channel_genesis_hash);
+		let block;
 
-		const block = channel.queryBlock(
-			parseInt(number),
-			client.getDefaultPeer(),
-			true
-		);
+		try {
+			block = await channel.queryBlock(
+				parseInt(number),
+				client.getDefaultPeer(),
+				true
+			);
+		} catch (e) {
+			logger.debug('queryBlock >> ', e);
+		}
 
 		if (block) {
 			return block;

--- a/app/platform/fabric/config.json
+++ b/app/platform/fabric/config.json
@@ -1,8 +1,12 @@
 {
 	"network-configs": {
-		"first-network": {
+		"first": {
 			"name": "first-network",
 			"profile": "./connection-profile/first-network.json"
+		},
+		"second": {
+			"name": "second-network",
+			"profile": "./connection-profile/second-network.json"
 		}
 	},
 	"license": "Apache-2.0"

--- a/app/platform/fabric/config.json
+++ b/app/platform/fabric/config.json
@@ -1,12 +1,8 @@
 {
 	"network-configs": {
-		"first": {
+		"first-network": {
 			"name": "first-network",
 			"profile": "./connection-profile/first-network.json"
-		},
-		"second": {
-			"name": "second-network",
-			"profile": "./connection-profile/second-network.json"
 		}
 	},
 	"license": "Apache-2.0"

--- a/app/platform/fabric/connection-profile/first-network.json
+++ b/app/platform/fabric/connection-profile/first-network.json
@@ -7,7 +7,7 @@
 		"adminUser": "admin",
 		"adminPassword": "adminpw",
 		"enableAuthentication": false,
-		"organization": "Org1",
+		"organization": "Org1MSP",
 		"connection": {
 			"timeout": {
 				"peer": {
@@ -38,17 +38,17 @@
 			"mspid": "Org1MSP",
 			"fullpath": true,
 			"adminPrivateKey": {
-				"path": "/fabric-path/fabric-samples/first-network/crypto-config/peerOrganizations/org1.example.com/users/Admin@org1.example.com/msp/keystore/1bebc656f198efb4b5bed08ef42cf3b2d89ac86f0a6b928e7a172fd823df0a48_sk"
+				"path": "/home/atsushi/hyperledger/fabric-samples/first-network/crypto-config/peerOrganizations/org1.example.com/users/Admin@org1.example.com/msp/keystore/sk"
 			},
 			"signedCert": {
-				"path": "/fabric-path/fabric-samples/first-network/crypto-config/peerOrganizations/org1.example.com/users/Admin@org1.example.com/msp/signcerts/Admin@org1.example.com-cert.pem"
+				"path": "/home/atsushi/hyperledger/fabric-samples/first-network/crypto-config/peerOrganizations/org1.example.com/users/Admin@org1.example.com/msp/signcerts/Admin@org1.example.com-cert.pem"
 			}
 		}
 	},
 	"peers": {
 		"peer0.org1.example.com": {
 			"tlsCACerts": {
-				"path": "/fabric-path/fabric-samples/first-network/crypto-config/peerOrganizations/org1.example.com/peers/peer0.org1.example.com/tls/ca.crt"
+				"path": "/home/atsushi/hyperledger/fabric-samples/first-network/crypto-config/peerOrganizations/org1.example.com/peers/peer0.org1.example.com/tls/ca.crt"
 			},
 			"url": "grpcs://localhost:7051",
 			"eventUrl": "grpcs://localhost:7053",

--- a/app/platform/fabric/connection-profile/first-network.json
+++ b/app/platform/fabric/connection-profile/first-network.json
@@ -7,7 +7,7 @@
 		"adminUser": "admin",
 		"adminPassword": "adminpw",
 		"enableAuthentication": false,
-		"organization": "Org1MSP",
+		"organization": "Org1",
 		"connection": {
 			"timeout": {
 				"peer": {
@@ -38,17 +38,17 @@
 			"mspid": "Org1MSP",
 			"fullpath": true,
 			"adminPrivateKey": {
-				"path": "/home/atsushi/hyperledger/fabric-samples/first-network/crypto-config/peerOrganizations/org1.example.com/users/Admin@org1.example.com/msp/keystore/sk"
+				"path": "/fabric-path/fabric-samples/first-network/crypto-config/peerOrganizations/org1.example.com/users/Admin@org1.example.com/msp/keystore/1bebc656f198efb4b5bed08ef42cf3b2d89ac86f0a6b928e7a172fd823df0a48_sk"
 			},
 			"signedCert": {
-				"path": "/home/atsushi/hyperledger/fabric-samples/first-network/crypto-config/peerOrganizations/org1.example.com/users/Admin@org1.example.com/msp/signcerts/Admin@org1.example.com-cert.pem"
+				"path": "/fabric-path/fabric-samples/first-network/crypto-config/peerOrganizations/org1.example.com/users/Admin@org1.example.com/msp/signcerts/Admin@org1.example.com-cert.pem"
 			}
 		}
 	},
 	"peers": {
 		"peer0.org1.example.com": {
 			"tlsCACerts": {
-				"path": "/home/atsushi/hyperledger/fabric-samples/first-network/crypto-config/peerOrganizations/org1.example.com/peers/peer0.org1.example.com/tls/ca.crt"
+				"path": "/fabric-path/fabric-samples/first-network/crypto-config/peerOrganizations/org1.example.com/peers/peer0.org1.example.com/tls/ca.crt"
 			},
 			"url": "grpcs://localhost:7051",
 			"eventUrl": "grpcs://localhost:7053",

--- a/app/platform/fabric/e2e-test/configs/connection-profile/org2-network.json
+++ b/app/platform/fabric/e2e-test/configs/connection-profile/org2-network.json
@@ -5,9 +5,9 @@
 	"client": {
 		"tlsEnable": true,
 		"adminUser": "admin",
-		"adminPassword": "adminpw",
-		"enableAuthentication": true,
+		"adminPassword": "org2adminpw",
 		"organization": "org2",
+		"enableAuthentication": false,
 		"connection": {
 			"timeout": {
 				"peer": {
@@ -18,7 +18,7 @@
 		}
 	},
 	"channels": {
-		"testorgschannel0": {
+		"commonchannel": {
 			"peers": {
 				"peer0-org2": {}
 			},
@@ -40,6 +40,7 @@
 			"adminPrivateKey": {
 				"path": "/tmp/crypto/peerOrganizations/org2/users/Admin@org2/msp/keystore/priv_sk"
 			},
+			"certificateAuthorities": ["ca0"],
 			"signedCert": {
 				"path": "/tmp/crypto/peerOrganizations/org2/users/Admin@org2/msp/signcerts/Admin@org2-cert.pem"
 			}
@@ -50,10 +51,22 @@
 			"tlsCACerts": {
 				"path": "/tmp/crypto/peerOrganizations/org2/peers/peer0-org2.org2/tls/ca.crt"
 			},
-			"url": "grpcs://peer0-org2:31000",
+			"url": "grpcs://peer0-org2:31002",
 			"grpcOptions": {
 				"ssl-target-name-override": "peer0-org2"
 			}
+		}
+	},
+	"certificateAuthorities": {
+		"ca0": {
+			"url": "https://ca0-org2:7054",
+			"httpOptions": {
+				"verify": false
+			},
+			"tlsCACerts": {
+				"path": "/tmp/crypto/peerOrganizations/org2/ca/ca.org2-cert.pem"
+			},
+			"caName": "ca0-org2"
 		}
 	}
 }

--- a/app/platform/fabric/e2e-test/configs/connection-profile/org2-network.json
+++ b/app/platform/fabric/e2e-test/configs/connection-profile/org2-network.json
@@ -5,7 +5,7 @@
 	"client": {
 		"tlsEnable": true,
 		"adminUser": "admin",
-		"adminPassword": "org2adminpw",
+		"adminPassword": "adminpw",
 		"organization": "org2",
 		"enableAuthentication": false,
 		"connection": {

--- a/app/platform/fabric/e2e-test/specs/apitest-input-multiprofile-invoke-common.yml
+++ b/app/platform/fabric/e2e-test/specs/apitest-input-multiprofile-invoke-common.yml
@@ -1,0 +1,31 @@
+organizations:
+  - name: org1
+#! For smoke test suite, connection-profile are read from smoke directory
+    connProfilePath: ./connection-profile/connection_profile_org1.yaml
+  - name: org2
+    connProfilePath: ./connection-profile/connection_profile_org2.yaml
+
+invokes:
+  - channelName: commonchannel
+    name: samplecc
+    targetPeers: OrgAnchor
+    nProcPerOrg: 1
+    nRequest: 1
+    runDur: 0
+    organizations: org1
+    txnOpt:
+      - mode: constant
+        options:
+          constFreq: 0
+          devFreq: 0
+    queryCheck: 100
+    eventOpt:
+      type: FilteredBlock
+      listener:  Block
+      timeout: 240000
+    ccOpt:
+      ccType: ccchecker
+      keyStart: 0
+      payLoadMin: 1024
+      payLoadMax: 2048
+    args: "put,a1,1"

--- a/app/platform/fabric/e2e-test/specs/apitest-input-multiprofile-invoke-org1.yml
+++ b/app/platform/fabric/e2e-test/specs/apitest-input-multiprofile-invoke-org1.yml
@@ -1,0 +1,31 @@
+organizations:
+  - name: org1
+#! For smoke test suite, connection-profile are read from smoke directory
+    connProfilePath: ./connection-profile/connection_profile_org1.yaml
+  - name: org2
+    connProfilePath: ./connection-profile/connection_profile_org2.yaml
+
+invokes:
+  - channelName: org1channel
+    name: samplecc
+    targetPeers: OrgAnchor
+    nProcPerOrg: 1
+    nRequest: 1
+    runDur: 0
+    organizations: org1
+    txnOpt:
+      - mode: constant
+        options:
+          constFreq: 0
+          devFreq: 0
+    queryCheck: 100
+    eventOpt:
+      type: FilteredBlock
+      listener:  Block
+      timeout: 240000
+    ccOpt:
+      ccType: ccchecker
+      keyStart: 0
+      payLoadMin: 1024
+      payLoadMax: 2048
+    args: "put,a1,1"

--- a/app/platform/fabric/e2e-test/specs/apitest-input-multiprofile-invoke-org2.yml
+++ b/app/platform/fabric/e2e-test/specs/apitest-input-multiprofile-invoke-org2.yml
@@ -1,0 +1,31 @@
+organizations:
+  - name: org1
+#! For smoke test suite, connection-profile are read from smoke directory
+    connProfilePath: ./connection-profile/connection_profile_org1.yaml
+  - name: org2
+    connProfilePath: ./connection-profile/connection_profile_org2.yaml
+
+invokes:
+  - channelName: org2channel
+    name: samplecc
+    targetPeers: OrgAnchor
+    nProcPerOrg: 1
+    nRequest: 1
+    runDur: 0
+    organizations: org2
+    txnOpt:
+      - mode: constant
+        options:
+          constFreq: 0
+          devFreq: 0
+    queryCheck: 100
+    eventOpt:
+      type: FilteredBlock
+      listener:  Block
+      timeout: 240000
+    ccOpt:
+      ccType: ccchecker
+      keyStart: 0
+      payLoadMin: 1024
+      payLoadMax: 2048
+    args: "put,a1,1"

--- a/app/platform/fabric/e2e-test/specs/apitest-input-multiprofile.yml
+++ b/app/platform/fabric/e2e-test/specs/apitest-input-multiprofile.yml
@@ -62,12 +62,26 @@ installChaincode:
     metadataPath: ""
 
 instantiateChaincode:
-  - channelName: testorgschannel0
+  - channelName: commonchannel
     name: samplecc
     version: v1
     args: ""
     organizations: org1
     endorsementPolicy: 2of(org1,org2)
+    collectionPath: ""
+  - channelName: org1channel
+    name: samplecc
+    version: v1
+    args: ""
+    organizations: org1
+    endorsementPolicy: 1of(org1)
+    collectionPath: ""
+  - channelName: org2channel
+    name: samplecc
+    version: v1
+    args: ""
+    organizations: org2
+    endorsementPolicy: 1of(org2)
     collectionPath: ""
 
 upgradeChaincode:
@@ -80,11 +94,11 @@ upgradeChaincode:
     collectionPath: ""
 
 invokes:
-  - channelName: testorgschannel0
+  - channelName: commonchannel
     name: samplecc
     targetPeers: OrgAnchor
-    nProcPerOrg: 2
-    nRequest: 10
+    nProcPerOrg: 1
+    nRequest: 1
     runDur: 0
     organizations: org1,org2
     txnOpt:

--- a/app/platform/fabric/e2e-test/specs/apitest_def_test.go
+++ b/app/platform/fabric/e2e-test/specs/apitest_def_test.go
@@ -1,0 +1,114 @@
+package apitest
+
+type UserData struct {
+	Message string `json:"message"`
+	Name    string `json:"name"`
+}
+
+type LoginResponse struct {
+	Status  int      `json:"status"`
+	Success bool     `json:"success"`
+	Message string   `json:"message"`
+	Token   string   `json:"token"`
+	User    UserData `json:"user"`
+}
+
+type RegisterResp struct {
+	Status  int    `json:"status"`
+	Message string `json:"message"`
+}
+
+type ChannelData struct {
+	ID                 int    `json:"id"`
+	Channelname        string `json:"channelname"`
+	Blocks             int    `json:"blocks"`
+	ChannelGenesisHash string `json:"channel_genesis_hash"`
+	Transactions       int    `json:"transactions"`
+	Createdat          string `json:"createdat"`
+	ChannelHash        string `json:"channel_hash"`
+}
+
+type ChannelsInfoResp struct {
+	Status   int           `json:"status"`
+	Channels []ChannelData `json:"channels"`
+}
+
+func (ch *ChannelsInfoResp) getChannelList() []string {
+	chList := []string{}
+	for _, val := range ch.Channels {
+		chList = append(chList, val.Channelname)
+	}
+	return chList
+}
+
+func (ch *ChannelsInfoResp) getChannelData(channelID string) *ChannelData {
+	var info *ChannelData
+	for _, val := range ch.Channels {
+		if val.Channelname == channelID {
+			info = &val
+			break
+		}
+	}
+	return info
+}
+
+func (ch *ChannelsInfoResp) getGenesisHash(channelID string) string {
+	var hash string
+	for _, val := range ch.Channels {
+		if val.Channelname == channelID {
+			hash = val.ChannelGenesisHash
+			break
+		}
+	}
+	return hash
+}
+
+func (ch *ChannelsInfoResp) getBlockHeight(channelID string) int {
+
+	var height int
+	for _, val := range ch.Channels {
+		if val.Channelname == channelID {
+			height = val.Blocks
+			break
+		}
+	}
+	return height
+}
+
+type ChannelsResponse struct {
+	Status   int      `json:"status"`
+	Channels []string `json:"channels"`
+}
+
+type BlockData struct {
+	Blocknum    int      `json:"blocknum"`
+	Txcount     int      `json:"txcount"`
+	Datahash    string   `json:"datahash"`
+	Blockhash   string   `json:"blockhash"`
+	Prehash     string   `json:"prehash"`
+	Createdt    string   `json:"createdt"`
+	Txhash      []string `json:"txhash"`
+	Channelname string   `json:"channelname"`
+}
+
+type BlockActivityResp struct {
+	Status int         `json:"status"`
+	Row    []BlockData `json:"row"`
+}
+
+type BlockResp struct {
+	Status       int           `json:"status"`
+	Number       string        `json:"number"`
+	PreviousHash string        `json:"previous_hash"`
+	DataHash     string        `json:"data_hash"`
+	Transactions []interface{} `json:"transactions"`
+}
+
+type PeersStatusResp struct {
+	Status int           `json:"status"`
+	Peers  []interface{} `json:"peers"`
+}
+
+type NetworklistInfo struct {
+	NetworkList [][]interface{} `json:"networkList"`
+}

--- a/app/platform/fabric/e2e-test/specs/apitest_suite_test.go
+++ b/app/platform/fabric/e2e-test/specs/apitest_suite_test.go
@@ -1,8 +1,10 @@
 package apitest
 
 import (
+	"strings"
 	"testing"
 
+	"github.com/hyperledger/fabric-test/tools/operator/networkclient"
 	. "github.com/onsi/ginkgo"
 	"github.com/onsi/ginkgo/reporters"
 	. "github.com/onsi/gomega"
@@ -22,20 +24,20 @@ var _ = BeforeSuite(func() {
 // and chaincode container images using AfterSuite
 var _ = AfterSuite(func() {
 
-	// dockerList := []string{"ps", "-aq", "-f", "status=exited"}
-	// containerList, _ := networkclient.ExecuteCommand("docker", dockerList, false)
-	// if containerList != "" {
-	// 	list := strings.Split(containerList, "\n")
-	// 	containerArgs := []string{"rm", "-f"}
-	// 	containerArgs = append(containerArgs, list...)
-	// 	networkclient.ExecuteCommand("docker", containerArgs, true)
-	// }
-	// ccimagesList := []string{"images", "-q", "--filter=reference=dev*"}
-	// images, _ := networkclient.ExecuteCommand("docker", ccimagesList, false)
-	// if images != "" {
-	// 	list := strings.Split(images, "\n")
-	// 	imageArgs := []string{"rmi", "-f"}
-	// 	imageArgs = append(imageArgs, list...)
-	// 	networkclient.ExecuteCommand("docker", imageArgs, true)
-	// }
+	dockerList := []string{"ps", "-aq", "-f", "status=exited"}
+	containerList, _ := networkclient.ExecuteCommand("docker", dockerList, false)
+	if containerList != "" {
+		list := strings.Split(containerList, "\n")
+		containerArgs := []string{"rm", "-f"}
+		containerArgs = append(containerArgs, list...)
+		networkclient.ExecuteCommand("docker", containerArgs, true)
+	}
+	ccimagesList := []string{"images", "-q", "--filter=reference=dev*"}
+	images, _ := networkclient.ExecuteCommand("docker", ccimagesList, false)
+	if images != "" {
+		list := strings.Split(images, "\n")
+		imageArgs := []string{"rmi", "-f"}
+		imageArgs = append(imageArgs, list...)
+		networkclient.ExecuteCommand("docker", imageArgs, true)
+	}
 })

--- a/app/platform/fabric/e2e-test/specs/apitest_suite_test.go
+++ b/app/platform/fabric/e2e-test/specs/apitest_suite_test.go
@@ -1,15 +1,11 @@
 package apitest
 
 import (
-	"strings"
 	"testing"
 
 	. "github.com/onsi/ginkgo"
 	"github.com/onsi/ginkgo/reporters"
 	. "github.com/onsi/gomega"
-
-	"github.com/hyperledger/fabric-test/tools/operator/launcher"
-	"github.com/hyperledger/fabric-test/tools/operator/networkclient"
 )
 
 func TestRestApi(t *testing.T) {
@@ -20,32 +16,26 @@ func TestRestApi(t *testing.T) {
 
 // Bringing up network using BeforeSuite
 var _ = BeforeSuite(func() {
-	networkSpecPath := "apitest-network-spec.yml"
-	err := launcher.Launcher("up", "docker", "", networkSpecPath)
-	Expect(err).NotTo(HaveOccurred())
 })
 
 // Cleaning up network launched from BeforeSuite and removing all chaincode containers
 // and chaincode container images using AfterSuite
 var _ = AfterSuite(func() {
-	networkSpecPath := "apitest-network-spec.yml"
-	err := launcher.Launcher("down", "docker", "", networkSpecPath)
-	Expect(err).NotTo(HaveOccurred())
 
-	dockerList := []string{"ps", "-aq", "-f", "status=exited"}
-	containerList, _ := networkclient.ExecuteCommand("docker", dockerList, false)
-	if containerList != "" {
-		list := strings.Split(containerList, "\n")
-		containerArgs := []string{"rm", "-f"}
-		containerArgs = append(containerArgs, list...)
-		networkclient.ExecuteCommand("docker", containerArgs, true)
-	}
-	ccimagesList := []string{"images", "-q", "--filter=reference=dev*"}
-	images, _ := networkclient.ExecuteCommand("docker", ccimagesList, false)
-	if images != "" {
-		list := strings.Split(images, "\n")
-		imageArgs := []string{"rmi", "-f"}
-		imageArgs = append(imageArgs, list...)
-		networkclient.ExecuteCommand("docker", imageArgs, true)
-	}
+	// dockerList := []string{"ps", "-aq", "-f", "status=exited"}
+	// containerList, _ := networkclient.ExecuteCommand("docker", dockerList, false)
+	// if containerList != "" {
+	// 	list := strings.Split(containerList, "\n")
+	// 	containerArgs := []string{"rm", "-f"}
+	// 	containerArgs = append(containerArgs, list...)
+	// 	networkclient.ExecuteCommand("docker", containerArgs, true)
+	// }
+	// ccimagesList := []string{"images", "-q", "--filter=reference=dev*"}
+	// images, _ := networkclient.ExecuteCommand("docker", ccimagesList, false)
+	// if images != "" {
+	// 	list := strings.Split(images, "\n")
+	// 	imageArgs := []string{"rmi", "-f"}
+	// 	imageArgs = append(imageArgs, list...)
+	// 	networkclient.ExecuteCommand("docker", imageArgs, true)
+	// }
 })

--- a/app/platform/fabric/e2e-test/specs/apitest_test.go
+++ b/app/platform/fabric/e2e-test/specs/apitest_test.go
@@ -6,6 +6,7 @@ import (
 	"os/exec"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/go-resty/resty/v2"
 	. "github.com/onsi/ginkgo"
@@ -15,73 +16,6 @@ import (
 	"github.com/hyperledger/fabric-test/tools/operator/networkclient"
 	"github.com/hyperledger/fabric-test/tools/operator/testclient"
 )
-
-type UserData struct {
-	Message string `json:"message"`
-	Name    string `json:"name"`
-}
-
-type LoginResponse struct {
-	Status  int      `json:"status"`
-	Success bool     `json:"success"`
-	Message string   `json:"message"`
-	Token   string   `json:"token"`
-	User    UserData `json:"user"`
-}
-
-type RegisterResp struct {
-	Status  int    `json:"status"`
-	Message string `json:"message"`
-}
-
-type ChannelData struct {
-	ID                 int    `json:"id"`
-	Channelname        string `json:"channelname"`
-	Blocks             int    `json:"blocks"`
-	ChannelGenesisHash string `json:"channel_genesis_hash"`
-	Transactions       int    `json:"transactions"`
-	Createdat          string `json:"createdat"`
-	ChannelHash        string `json:"channel_hash"`
-}
-
-type ChannelsInfoResp struct {
-	Status   int           `json:"status"`
-	Channels []ChannelData `json:"channels"`
-}
-
-type ChannelsResponse struct {
-	Status   int      `json:"status"`
-	Channels []string `json:"channels"`
-}
-
-type BlockData struct {
-	Blocknum    int      `json:"blocknum"`
-	Txcount     int      `json:"txcount"`
-	Datahash    string   `json:"datahash"`
-	Blockhash   string   `json:"blockhash"`
-	Prehash     string   `json:"prehash"`
-	Createdt    string   `json:"createdt"`
-	Txhash      []string `json:"txhash"`
-	Channelname string   `json:"channelname"`
-}
-
-type BlockActivityResp struct {
-	Status int         `json:"status"`
-	Row    []BlockData `json:"row"`
-}
-
-type BlockResp struct {
-	Status       int           `json:"status"`
-	Number       string        `json:"number"`
-	PreviousHash string        `json:"previous_hash"`
-	DataHash     string        `json:"data_hash"`
-	Transactions []interface{} `json:"transactions"`
-}
-
-type PeersStatusResp struct {
-	Status int           `json:"status"`
-	Peers  []interface{} `json:"peers"`
-}
 
 var (
 	channelMonitored    string
@@ -119,28 +53,81 @@ func StopNode(nodeName string) {
 	}
 }
 
-var _ = XDescribe("REST API Test Suite - Single profile", func() {
+func restGet(path string, data interface{}) *resty.Response {
+	return restGetWithToken(path, data, "")
+}
 
-	BeforeEach(func() {
-		networkSpecPath := "apitest-network-spec.yml"
-		err := launcher.Launcher("up", "docker", "", networkSpecPath)
-		Expect(err).NotTo(HaveOccurred())
-	})
+func restGetWithToken(path string, data interface{}, token string) *resty.Response {
+	client := resty.New()
+	if len(token) != 0 {
+		client.SetAuthToken(token)
+	}
 
-	AfterEach(func() {
-		networkSpecPath := "apitest-network-spec.yml"
-		err := launcher.Launcher("down", "docker", "", networkSpecPath)
-		Expect(err).NotTo(HaveOccurred())
-	})
+	resp, err := client.R().
+		EnableTrace().
+		SetResult(data).
+		Get("http://localhost:8090" + path)
+
+	Expect(err).ShouldNot(HaveOccurred())
+	return resp
+}
+
+func compareChannelsInfoBlockCount(before *ChannelsInfoResp, after *ChannelsInfoResp, channel string, expectDiff int) {
+	beforeData := before.getChannelData(channel)
+	Expect(beforeData).ShouldNot(Equal(nil))
+	afterData := after.getChannelData(channel)
+	Expect(afterData).ShouldNot(Equal(nil))
+	diff := afterData.Blocks - beforeData.Blocks
+	Expect(diff).Should(Equal(expectDiff))
+}
+
+func compareChannelsInfoTxCount(before *ChannelsInfoResp, after *ChannelsInfoResp, channel string, expectDiff int) {
+	beforeData := before.getChannelData(channel)
+	Expect(beforeData).ShouldNot(Equal(nil))
+	afterData := after.getChannelData(channel)
+	Expect(afterData).ShouldNot(Equal(nil))
+	diff := afterData.Transactions - beforeData.Transactions
+	Expect(diff).Should(Equal(expectDiff))
+}
+
+func restPost(path string, body interface{}, data interface{}) *resty.Response {
+	return restPostWithToken(path, body, data, "")
+}
+
+func restPostWithToken(path string, body interface{}, data interface{}, token string) *resty.Response {
+	client := resty.New()
+	if len(token) != 0 {
+		client.SetAuthToken(token)
+	}
+	resp, err := client.R().
+		EnableTrace().
+		SetHeader("Content-Type", "application/json").
+		SetBody(body).
+		SetResult(data).
+		Post("http://localhost:8090" + path)
+
+	Expect(err).ShouldNot(HaveOccurred())
+	return resp
+}
+
+var _ = Describe("REST API Test Suite - Single profile", func() {
 
 	Describe("Running REST API Test Suite in fabric-test", func() {
 		var (
 			action             string
+			networkSpecPath    string
 			inputSpecPath      string
 			token              string
 			channelGenesisHash string
 			blockHeight        int
 		)
+
+		It("Starting fabric network", func() {
+			networkSpecPath = "apitest-network-spec.yml"
+			err := launcher.Launcher("up", "docker", "", networkSpecPath)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
 		It("starting fabric network", func() {
 			out, err := exec.Command("pwd").Output()
 			if err != nil {
@@ -196,19 +183,8 @@ var _ = XDescribe("REST API Test Suite - Single profile", func() {
 		})
 
 		It("get network list", func() {
-			type NetworklistInfo struct {
-				NetworkList [][]interface{} `json:"networkList"`
-			}
 
-			// Create a Resty Client
-			client := resty.New()
-
-			resp, err := client.R().
-				EnableTrace().
-				SetResult(&NetworklistInfo{}).
-				Get("http://localhost:8090/auth/networklist")
-
-			Expect(err).ShouldNot(HaveOccurred())
+			resp := restGet("/auth/networklist", &NetworklistInfo{})
 
 			result := resp.Result().(*NetworklistInfo)
 			list := []string{}
@@ -217,22 +193,11 @@ var _ = XDescribe("REST API Test Suite - Single profile", func() {
 			}
 			Expect(list).Should(HaveLen(1))
 			Expect(list).Should(ContainElements([]string{"org1-network"}))
-
 		})
 
 		It("login to org1-network", func() {
 
-			client := resty.New()
-
-			resp, err := client.R().
-				EnableTrace().
-				SetHeader("Content-Type", "application/json").
-				SetBody(map[string]interface{}{"user": "admin", "password": "adminpw", "network": "org1-network"}).
-				SetResult(&LoginResponse{}).
-				Post("http://localhost:8090/auth/login")
-
-			Expect(err).ShouldNot(HaveOccurred())
-
+			resp := restPost("/auth/login", map[string]interface{}{"user": "admin", "password": "adminpw", "network": "org1-network"}, &LoginResponse{})
 			result := resp.Result().(*LoginResponse)
 			token = result.Token
 
@@ -241,126 +206,49 @@ var _ = XDescribe("REST API Test Suite - Single profile", func() {
 		})
 
 		It("get channels", func() {
-
-			client := resty.New()
-			client.SetAuthToken(token)
-
-			resp, err := client.R().
-				EnableTrace().
-				SetResult(&ChannelsResponse{}).
-				Get("http://localhost:8090/api/channels")
-
-			Expect(err).ShouldNot(HaveOccurred())
-
+			resp := restGetWithToken("/api/channels", &ChannelsResponse{}, token)
 			result := resp.Result().(*ChannelsResponse)
-
 			Expect(result.Channels).Should(ContainElements([]string{"org1channel", "commonchannel"}))
-
+			Expect(len(result.Channels)).Should(Equal(2))
 		})
 
 		It("get channels info", func() {
-
-			client := resty.New()
-			client.SetAuthToken(token)
-
-			resp, err := client.R().
-				EnableTrace().
-				SetResult(&ChannelsInfoResp{}).
-				Get("http://localhost:8090/api/channels/info")
-
-			Expect(err).ShouldNot(HaveOccurred())
-
+			resp := restGetWithToken("/api/channels/info", &ChannelsInfoResp{}, token)
 			result := resp.Result().(*ChannelsInfoResp)
-			chList := []string{}
-			for _, ch := range result.Channels {
-				chList = append(chList, ch.Channelname)
-				if ch.Channelname == "commonchannel" {
-					channelGenesisHash = ch.ChannelGenesisHash
-					blockHeight = ch.Blocks - 1
-				}
-			}
-			// Expect(result.Channels[0].Channelname).Should(Equal("commonchannel"))
+			chList := result.getChannelList()
+			channelGenesisHash = result.getGenesisHash("commonchannel")
+			blockHeight = result.getBlockHeight("commonchannel") - 1
 			Expect(chList).Should(ContainElements([]string{"commonchannel", "org1channel"}))
-
+			Expect(len(chList)).Should(Equal(2))
 		})
 
 		It("get block info", func() {
-
-			client := resty.New()
-			client.SetAuthToken(token)
-
-			resp, err := client.R().
-				EnableTrace().
-				SetResult(&BlockResp{}).
-				Get("http://localhost:8090/api/block/" + channelGenesisHash + "/" + strconv.Itoa(blockHeight))
-
-			Expect(err).ShouldNot(HaveOccurred())
+			resp := restGetWithToken("/api/block/"+channelGenesisHash+"/"+strconv.Itoa(blockHeight), &BlockResp{}, token)
 			result := resp.Result().(*BlockResp)
 			Expect(result.Status).Should(Equal(200))
-
 		})
 
 		It("get status of peers within commonchannel", func() {
-
-			client := resty.New()
-			client.SetAuthToken(token)
-
-			resp, err := client.R().
-				EnableTrace().
-				SetResult(&PeersStatusResp{}).
-				Get("http://localhost:8090/api/peersStatus/" + "commonchannel")
-
-			Expect(err).ShouldNot(HaveOccurred())
+			resp := restGetWithToken("/api/peersStatus/"+"commonchannel", &PeersStatusResp{}, token)
 			result := resp.Result().(*PeersStatusResp)
 			Expect(result.Status).Should(Equal(200))
 		})
 
 		It("get block activity", func() {
-
-			client := resty.New()
-			client.SetAuthToken(token)
-
-			resp, err := client.R().
-				EnableTrace().
-				SetResult(&BlockActivityResp{}).
-				Get("http://localhost:8090/api/blockActivity/" + channelGenesisHash)
-
-			Expect(err).ShouldNot(HaveOccurred())
+			resp := restGetWithToken("/api/blockActivity/"+channelGenesisHash, &BlockActivityResp{}, token)
 			result := resp.Result().(*BlockActivityResp)
 			Expect(result.Status).Should(Equal(200))
 			Expect(result.Row[0].Channelname).Should(Equal("commonchannel"))
 		})
 
 		It("register user", func() {
-
-			client := resty.New()
-			client.SetAuthToken(token)
-			resp, err := client.R().
-				EnableTrace().
-				SetHeader("Content-Type", "application/json").
-				SetBody(map[string]interface{}{"user": "test", "password": "test", "affiliation": "department2", "role": "admin"}).
-				SetResult(&RegisterResp{}).
-				Post("http://localhost:8090/api/register")
-
-			Expect(err).ShouldNot(HaveOccurred())
+			resp := restPostWithToken("/api/register", map[string]interface{}{"user": "test", "password": "test", "affiliation": "department2", "role": "admin"}, &RegisterResp{}, token)
 			resultRegister := resp.Result().(*RegisterResp)
 			Expect(resultRegister.Status).Should(Equal(200))
 		})
 
 		It("login with newly registered user", func() {
-
-			client := resty.New()
-			client.SetAuthToken(token)
-
-			resp, err := client.R().
-				EnableTrace().
-				SetHeader("Content-Type", "application/json").
-				SetBody(map[string]interface{}{"user": "test", "password": "test", "network": "org1-network"}).
-				SetResult(&LoginResponse{}).
-				Post("http://localhost:8090/auth/login")
-
-			Expect(err).ShouldNot(HaveOccurred())
-
+			resp := restPost("/auth/login", map[string]interface{}{"user": "test", "password": "test", "network": "org1-network"}, &LoginResponse{})
 			resultLogin := resp.Result().(*LoginResponse)
 
 			Expect(resultLogin.User.Message).Should(Equal("logged in"))
@@ -368,17 +256,7 @@ var _ = XDescribe("REST API Test Suite - Single profile", func() {
 		})
 
 		It("fail to register duplicate user", func() {
-
-			client := resty.New()
-			client.SetAuthToken(token)
-			resp, err := client.R().
-				EnableTrace().
-				SetHeader("Content-Type", "application/json").
-				SetBody(map[string]interface{}{"user": "test", "password": "test", "affiliation": "department2", "role": "admin"}).
-				SetResult(&RegisterResp{}).
-				Post("http://localhost:8090/api/register")
-
-			Expect(err).ShouldNot(HaveOccurred())
+			resp := restPostWithToken("/api/register", map[string]interface{}{"user": "test", "password": "test", "affiliation": "department2", "role": "admin"}, &RegisterResp{}, token)
 			resultRegister := resp.Result().(*RegisterResp)
 			Expect(resultRegister.Status).Should(Equal(400))
 			Expect(resultRegister.Message).Should(Equal("Error: already exists"))
@@ -418,27 +296,12 @@ var _ = XDescribe("REST API Test Suite - Single profile", func() {
 				action = "invoke"
 				err = testclient.Testclient(action, inputSpecPath)
 				Expect(err).NotTo(HaveOccurred())
-
-				By("7) Retrieving channels again")
-				client := resty.New()
-				client.SetAuthToken(token)
-
 			})
 
 			It("Should include the newly added channel when retrieving channels again", func() {
-
-				client := resty.New()
-				client.SetAuthToken(token)
-
-				resp, err := client.R().
-					EnableTrace().
-					SetResult(&ChannelsResponse{}).
-					Get("http://localhost:8090/api/channels")
-				Expect(err).ShouldNot(HaveOccurred())
-
+				resp := restGetWithToken("/api/channels", &ChannelsResponse{}, token)
 				result := resp.Result().(*ChannelsResponse)
 				Expect(result.Channels).Should(ContainElements([]string{"org1channel", "commonchannel", "channel2422422422422422422422422422422422422422422422422422422422422422422422422422422422422422422422422422422422422422422422422422422422422422422422422422422422422422422422422422422422422422422422422422422422422422422422422422422422422422422"}))
-
 			})
 
 			It("Should create a new event hub for the newly added channel within 60s", func() {
@@ -464,6 +327,28 @@ var _ = XDescribe("REST API Test Suite - Single profile", func() {
 			Expect(err).NotTo(HaveOccurred())
 		})
 
+		It("Shutdown network", func() {
+			err := launcher.Launcher("down", "docker", "", networkSpecPath)
+			Expect(err).NotTo(HaveOccurred())
+
+			dockerList := []string{"ps", "-aq", "-f", "status=exited"}
+			containerList, _ := networkclient.ExecuteCommand("docker", dockerList, false)
+			if containerList != "" {
+				list := strings.Split(containerList, "\n")
+				containerArgs := []string{"rm", "-f"}
+				containerArgs = append(containerArgs, list...)
+				networkclient.ExecuteCommand("docker", containerArgs, true)
+			}
+			ccimagesList := []string{"images", "-q", "--filter=reference=dev*"}
+			images, _ := networkclient.ExecuteCommand("docker", ccimagesList, false)
+			if images != "" {
+				list := strings.Split(images, "\n")
+				imageArgs := []string{"rmi", "-f"}
+				imageArgs = append(imageArgs, list...)
+				networkclient.ExecuteCommand("docker", imageArgs, true)
+			}
+		})
+
 	})
 })
 
@@ -471,21 +356,18 @@ var _ = Describe("REST API Test Suite - Multiple profile", func() {
 
 	Describe("Running REST API Test Suite in fabric-test", func() {
 		var (
-			action             string
-			networkSpecPath    string
-			inputSpecPath      string
-			token              string
-			channelGenesisHash string
-			blockHeight        int
+			action          string
+			networkSpecPath string
+			inputSpecPath   string
 		)
 
-		XIt("Starting fabric network", func() {
+		It("Starting fabric network", func() {
 			networkSpecPath = "apitest-network-spec.yml"
 			err := launcher.Launcher("up", "docker", "", networkSpecPath)
 			Expect(err).NotTo(HaveOccurred())
 		})
 
-		XIt("Setup fabric network", func() {
+		It("Setup fabric network", func() {
 
 			inputSpecPath = "apitest-input-multiprofile.yml"
 
@@ -525,327 +407,340 @@ var _ = Describe("REST API Test Suite - Multiple profile", func() {
 
 		})
 
-		XIt("launch explorer", func() {
+		It("launch explorer", func() {
 			_, err := networkclient.ExecuteCommand("./runexplorer.sh", []string{"multi"}, true)
 			Expect(err).NotTo(HaveOccurred())
 		})
 
-		XIt("get network list", func() {
-			type NetworklistInfo struct {
-				NetworkList [][]interface{} `json:"networkList"`
-			}
-
-			// Create a Resty Client
-			client := resty.New()
-
-			resp, err := client.R().
-				EnableTrace().
-				SetResult(&NetworklistInfo{}).
-				Get("http://localhost:8090/auth/networklist")
-
-			Expect(err).ShouldNot(HaveOccurred())
-
-			result := resp.Result().(*NetworklistInfo)
-			list := []string{}
-			for _, val := range result.NetworkList {
-				list = append(list, val[0].(string))
-			}
-			Expect(list).Should(HaveLen(2))
-			Expect(list).Should(ContainElements([]string{"org1-network", "org2-network"}))
-
-		})
-
-		It("login to org2-network", func() {
-
-			client := resty.New()
-
-			resp, err := client.R().
-				EnableTrace().
-				SetHeader("Content-Type", "application/json").
-				SetBody(map[string]interface{}{"user": "admin", "password": "org2adminpw", "network": "org2-network"}).
-				SetResult(&LoginResponse{}).
-				Post("http://localhost:8090/auth/login")
-
-			Expect(err).ShouldNot(HaveOccurred())
-
-			result := resp.Result().(*LoginResponse)
-			token = result.Token
-
-			Expect(result.User.Message).Should(Equal("logged in"))
-			Expect(result.User.Name).Should(Equal("admin"))
-		})
-
-		XIt("get channels", func() {
-
-			client := resty.New()
-			client.SetAuthToken(token)
-
-			resp, err := client.R().
-				EnableTrace().
-				SetResult(&ChannelsResponse{}).
-				Get("http://localhost:8090/api/channels")
-
-			Expect(err).ShouldNot(HaveOccurred())
-
-			result := resp.Result().(*ChannelsResponse)
-
-			Expect(result.Channels).Should(ContainElements([]string{"org2channel", "commonchannel"}))
-
-		})
-
-		It("get channels info", func() {
-
-			client := resty.New()
-			client.SetAuthToken(token)
-
-			resp, err := client.R().
-				EnableTrace().
-				SetResult(&ChannelsInfoResp{}).
-				Get("http://localhost:8090/api/channels/info")
-
-			Expect(err).ShouldNot(HaveOccurred())
-
-			result := resp.Result().(*ChannelsInfoResp)
-			chList := []string{}
-			for _, ch := range result.Channels {
-				chList = append(chList, ch.Channelname)
-				if ch.Channelname == "org2channel" {
-					channelGenesisHash = ch.ChannelGenesisHash
-					blockHeight = ch.Blocks - 1
+		Context("/auth/networklist", func() {
+			It("get network list", func() {
+				resp := restGet("/auth/networklist", &NetworklistInfo{})
+				result := resp.Result().(*NetworklistInfo)
+				list := []string{}
+				for _, val := range result.NetworkList {
+					list = append(list, val[0].(string))
 				}
-			}
-			// Expect(result.Channels[0].Channelname).Should(Equal("commonchannel"))
-			Expect(chList).Should(ContainElements([]string{"commonchannel", "org2channel"}))
-			Expect(blockHeight).Should(Equal(2))
+				Expect(list).Should(HaveLen(2))
+				Expect(list).Should(ContainElements([]string{"org1-network", "org2-network"}))
 
+			})
 		})
 
-		It("get block info", func() {
+		Context("/auth/login", func() {
+			It("login to org1-network", func() {
+				resp := restPost("/auth/login", map[string]interface{}{"user": "admin", "password": "adminpw", "network": "org1-network"}, &LoginResponse{})
+				result := resp.Result().(*LoginResponse)
+				Expect(result.User.Message).Should(Equal("logged in"))
+				Expect(result.User.Name).Should(Equal("admin"))
+			})
 
-			client := resty.New()
-			client.SetAuthToken(token)
-
-			resp, err := client.R().
-				EnableTrace().
-				SetResult(&BlockResp{}).
-				Get("http://localhost:8090/api/block/" + channelGenesisHash + "/" + strconv.Itoa(blockHeight))
-
-			Expect(err).ShouldNot(HaveOccurred())
-			result := resp.Result().(*BlockResp)
-			Expect(result.Status).Should(Equal(200))
-
+			It("login to org2-network", func() {
+				resp := restPost("/auth/login", map[string]interface{}{"user": "admin", "password": "adminpw", "network": "org2-network"}, &LoginResponse{})
+				result := resp.Result().(*LoginResponse)
+				Expect(result.User.Message).Should(Equal("logged in"))
+				Expect(result.User.Name).Should(Equal("admin"))
+			})
 		})
 
-		It("get status of peers within org2channel", func() {
+		Context("/api/channels", func() {
+			It("get channels for Org1", func() {
+				// For org1
+				resp := restPost("/auth/login", map[string]interface{}{"user": "admin", "password": "adminpw", "network": "org1-network"}, &LoginResponse{})
+				resultLogin := resp.Result().(*LoginResponse)
+				token := resultLogin.Token
+				Expect(resultLogin.User.Message).Should(Equal("logged in"))
 
-			client := resty.New()
-			client.SetAuthToken(token)
+				resp = restGetWithToken("/api/channels", &ChannelsResponse{}, token)
+				result := resp.Result().(*ChannelsResponse)
+				Expect(result.Channels).Should(ContainElements([]string{"org1channel", "commonchannel"}))
+				Expect(len(result.Channels)).Should(Equal(2))
+			})
 
-			resp, err := client.R().
-				EnableTrace().
-				SetResult(&PeersStatusResp{}).
-				Get("http://localhost:8090/api/peersStatus/" + "org2channel")
+			It("get channels for Org2", func() {
+				// For org2
+				resp := restPost("/auth/login", map[string]interface{}{"user": "admin", "password": "adminpw", "network": "org2-network"}, &LoginResponse{})
+				resultLogin := resp.Result().(*LoginResponse)
+				token := resultLogin.Token
+				Expect(resultLogin.User.Message).Should(Equal("logged in"))
 
-			Expect(err).ShouldNot(HaveOccurred())
-			result := resp.Result().(*PeersStatusResp)
-			Expect(result.Status).Should(Equal(200))
+				resp = restGetWithToken("/api/channels", &ChannelsResponse{}, token)
+				result := resp.Result().(*ChannelsResponse)
+				Expect(result.Channels).Should(ContainElements([]string{"org2channel", "commonchannel"}))
+				Expect(len(result.Channels)).Should(Equal(2))
+			})
 		})
 
-		It("get block activity", func() {
+		Context("/api/channels/info", func() {
 
-			client := resty.New()
-			client.SetAuthToken(token)
+			It("get channels info for org1", func() {
+				resp1 := restPost("/auth/login", map[string]interface{}{"user": "admin", "password": "adminpw", "network": "org1-network"}, &LoginResponse{})
+				result1 := resp1.Result().(*LoginResponse)
+				token := result1.Token
+				Expect(result1.User.Message).Should(Equal("logged in"))
 
-			resp, err := client.R().
-				EnableTrace().
-				SetResult(&BlockActivityResp{}).
-				Get("http://localhost:8090/api/blockActivity/" + channelGenesisHash)
+				resp2 := restGetWithToken("/api/channels/info", &ChannelsInfoResp{}, token)
+				result2 := resp2.Result().(*ChannelsInfoResp)
+				chList := result2.getChannelList()
+				Expect(chList).Should(ContainElements([]string{"commonchannel", "org1channel"}))
+				Expect(len(chList)).Should(Equal(2))
 
-			Expect(err).ShouldNot(HaveOccurred())
-			result := resp.Result().(*BlockActivityResp)
-			Expect(result.Status).Should(Equal(200))
-			Expect(result.Row[0].Channelname).Should(Equal("org2channel"))
-			org2CurrentBlockNum = result.Row[0].Blocknum
-		})
-
-		It("Update block on org1channel and should not have any changes on org2channel", func() {
-			action = "invoke"
-			inputSpecPath = "apitest-input-multiprofile-invoke-org1.yml"
-			err := testclient.Testclient(action, inputSpecPath)
-			Expect(err).NotTo(HaveOccurred())
-
-			client := resty.New()
-			client.SetAuthToken(token)
-
-			resp, err := client.R().
-				EnableTrace().
-				SetResult(&BlockActivityResp{}).
-				Get("http://localhost:8090/api/blockActivity/" + channelGenesisHash)
-
-			Expect(err).ShouldNot(HaveOccurred())
-			result := resp.Result().(*BlockActivityResp)
-			Expect(result.Status).Should(Equal(200))
-			Expect(result.Row[0].Channelname).Should(Equal("org2channel"))
-			Expect(result.Row[0].Blocknum).Should(Equal(org2CurrentBlockNum))
-		})
-
-		It("Update block on org2channel and should have some changes on org2channel", func() {
-			action = "invoke"
-			inputSpecPath = "apitest-input-multiprofile-invoke-org2.yml"
-			err := testclient.Testclient(action, inputSpecPath)
-			Expect(err).NotTo(HaveOccurred())
-
-			client := resty.New()
-			client.SetAuthToken(token)
-
-			resp, err := client.R().
-				EnableTrace().
-				SetResult(&BlockActivityResp{}).
-				Get("http://localhost:8090/api/blockActivity/" + channelGenesisHash)
-
-			Expect(err).ShouldNot(HaveOccurred())
-			result := resp.Result().(*BlockActivityResp)
-			Expect(result.Status).Should(Equal(200))
-			Expect(result.Row[0].Channelname).Should(Equal("org2channel"))
-			Expect(result.Row[0].Blocknum).Should(Equal(org2CurrentBlockNum + 1))
-		})
-
-		XIt("register user", func() {
-
-			client := resty.New()
-			client.SetAuthToken(token)
-			resp, err := client.R().
-				EnableTrace().
-				SetHeader("Content-Type", "application/json").
-				SetBody(map[string]interface{}{"user": "test", "password": "test", "affiliation": "department2", "role": "admin"}).
-				SetResult(&RegisterResp{}).
-				Post("http://localhost:8090/api/register")
-
-			Expect(err).ShouldNot(HaveOccurred())
-			resultRegister := resp.Result().(*RegisterResp)
-			Expect(resultRegister.Status).Should(Equal(200))
-		})
-
-		XIt("login with newly registered user", func() {
-
-			client := resty.New()
-			client.SetAuthToken(token)
-
-			resp, err := client.R().
-				EnableTrace().
-				SetHeader("Content-Type", "application/json").
-				SetBody(map[string]interface{}{"user": "test", "password": "test", "network": "org2-network"}).
-				SetResult(&LoginResponse{}).
-				Post("http://localhost:8090/auth/login")
-
-			Expect(err).ShouldNot(HaveOccurred())
-
-			resultLogin := resp.Result().(*LoginResponse)
-
-			Expect(resultLogin.User.Message).Should(Equal("logged in"))
-			Expect(resultLogin.User.Name).Should(Equal("test"))
-		})
-
-		XIt("fail to register duplicate user", func() {
-
-			client := resty.New()
-			client.SetAuthToken(token)
-			resp, err := client.R().
-				EnableTrace().
-				SetHeader("Content-Type", "application/json").
-				SetBody(map[string]interface{}{"user": "test", "password": "test", "affiliation": "department2", "role": "admin"}).
-				SetResult(&RegisterResp{}).
-				Post("http://localhost:8090/api/register")
-
-			Expect(err).ShouldNot(HaveOccurred())
-			resultRegister := resp.Result().(*RegisterResp)
-			Expect(resultRegister.Status).Should(Equal(400))
-			Expect(resultRegister.Message).Should(Equal("Error: already exists"))
-		})
-
-		XDescribe("Bugfix check:", func() {
-
-			It("Add new channel to org1 and explorer should detect it", func() {
-				inputSpecPath = "apitest-input-singleprofile_addnewch.yml"
-
-				By("1) Creating channel")
-				action := "create"
+				action := "invoke"
+				inputSpecPath = "apitest-input-multiprofile-invoke-org1.yml"
 				err := testclient.Testclient(action, inputSpecPath)
 				Expect(err).NotTo(HaveOccurred())
 
-				By("2) Joining Peers to channel")
-				action = "join"
-				err = testclient.Testclient(action, inputSpecPath)
-				Expect(err).NotTo(HaveOccurred())
+				time.Sleep(2 * time.Second)
 
-				By("3) Updating channel with anchor peers")
-				action = "anchorpeer"
-				err = testclient.Testclient(action, inputSpecPath)
-				Expect(err).NotTo(HaveOccurred())
+				resp3 := restGetWithToken("/api/channels/info", &ChannelsInfoResp{}, token)
+				result3 := resp3.Result().(*ChannelsInfoResp)
 
-				By("4) Instantiating Chaincode")
-				action = "instantiate"
-				err = testclient.Testclient(action, inputSpecPath)
-				Expect(err).NotTo(HaveOccurred())
+				compareChannelsInfoBlockCount(result2, result3, "commonchannel", 0)
+				compareChannelsInfoBlockCount(result2, result3, "org1channel", 1)
+				compareChannelsInfoTxCount(result2, result3, "commonchannel", 0)
+				compareChannelsInfoTxCount(result2, result3, "org1channel", 1)
 
-				By("5) Sending Queries")
-				action = "query"
-				err = testclient.Testclient(action, inputSpecPath)
-				Expect(err).NotTo(HaveOccurred())
-
-				By("6) Sending Invokes")
 				action = "invoke"
+				inputSpecPath = "apitest-input-multiprofile-invoke-org2.yml"
 				err = testclient.Testclient(action, inputSpecPath)
 				Expect(err).NotTo(HaveOccurred())
 
-				By("7) Retrieving channels again")
-				client := resty.New()
-				client.SetAuthToken(token)
+				time.Sleep(2 * time.Second)
 
+				resp4 := restGetWithToken("/api/channels/info", &ChannelsInfoResp{}, token)
+				result4 := resp4.Result().(*ChannelsInfoResp)
+
+				compareChannelsInfoBlockCount(result3, result4, "commonchannel", 0)
+				compareChannelsInfoBlockCount(result3, result4, "org1channel", 0)
+				compareChannelsInfoTxCount(result3, result4, "commonchannel", 0)
+				compareChannelsInfoTxCount(result3, result4, "org1channel", 0)
+
+				action = "invoke"
+				inputSpecPath = "apitest-input-multiprofile-invoke-common.yml"
+				err = testclient.Testclient(action, inputSpecPath)
+				Expect(err).NotTo(HaveOccurred())
+
+				time.Sleep(2 * time.Second)
+
+				resp5 := restGetWithToken("/api/channels/info", &ChannelsInfoResp{}, token)
+				result5 := resp5.Result().(*ChannelsInfoResp)
+
+				compareChannelsInfoBlockCount(result4, result5, "commonchannel", 1)
+				compareChannelsInfoBlockCount(result4, result5, "org1channel", 0)
+				compareChannelsInfoTxCount(result4, result5, "commonchannel", 1)
+				compareChannelsInfoTxCount(result4, result5, "org1channel", 0)
 			})
 
-			It("Should include the newly added channel when retrieving channels again", func() {
+			It("get channels info for org2", func() {
+				resp1 := restPost("/auth/login", map[string]interface{}{"user": "admin", "password": "adminpw", "network": "org2-network"}, &LoginResponse{})
+				result1 := resp1.Result().(*LoginResponse)
+				token := result1.Token
+				Expect(result1.User.Message).Should(Equal("logged in"))
 
-				client := resty.New()
-				client.SetAuthToken(token)
+				resp2 := restGetWithToken("/api/channels/info", &ChannelsInfoResp{}, token)
+				result2 := resp2.Result().(*ChannelsInfoResp)
+				chList := result2.getChannelList()
+				Expect(chList).Should(ContainElements([]string{"commonchannel", "org2channel"}))
+				Expect(len(chList)).Should(Equal(2))
 
-				resp, err := client.R().
-					EnableTrace().
-					SetResult(&ChannelsResponse{}).
-					Get("http://localhost:8090/api/channels")
-				Expect(err).ShouldNot(HaveOccurred())
+				action := "invoke"
+				inputSpecPath = "apitest-input-multiprofile-invoke-org1.yml"
+				err := testclient.Testclient(action, inputSpecPath)
+				Expect(err).NotTo(HaveOccurred())
 
-				result := resp.Result().(*ChannelsResponse)
-				Expect(result.Channels).Should(ContainElements([]string{"org1channel", "commonchannel", "channel2422422422422422422422422422422422422422422422422422422422422422422422422422422422422422422422422422422422422422422422422422422422422422422422422422422422422422422422422422422422422422422422422422422422422422422422422422422422422422422"}))
+				time.Sleep(2 * time.Second)
 
+				resp3 := restGetWithToken("/api/channels/info", &ChannelsInfoResp{}, token)
+				result3 := resp3.Result().(*ChannelsInfoResp)
+
+				compareChannelsInfoBlockCount(result2, result3, "commonchannel", 0)
+				compareChannelsInfoBlockCount(result2, result3, "org2channel", 0)
+				compareChannelsInfoTxCount(result2, result3, "commonchannel", 0)
+				compareChannelsInfoTxCount(result2, result3, "org2channel", 0)
+
+				action = "invoke"
+				inputSpecPath = "apitest-input-multiprofile-invoke-org2.yml"
+				err = testclient.Testclient(action, inputSpecPath)
+				Expect(err).NotTo(HaveOccurred())
+
+				time.Sleep(2 * time.Second)
+
+				resp4 := restGetWithToken("/api/channels/info", &ChannelsInfoResp{}, token)
+				result4 := resp4.Result().(*ChannelsInfoResp)
+
+				compareChannelsInfoBlockCount(result3, result4, "commonchannel", 0)
+				compareChannelsInfoBlockCount(result3, result4, "org2channel", 1)
+				compareChannelsInfoTxCount(result3, result4, "commonchannel", 0)
+				compareChannelsInfoTxCount(result3, result4, "org2channel", 1)
+
+				action = "invoke"
+				inputSpecPath = "apitest-input-multiprofile-invoke-common.yml"
+				err = testclient.Testclient(action, inputSpecPath)
+				Expect(err).NotTo(HaveOccurred())
+
+				time.Sleep(2 * time.Second)
+
+				resp5 := restGetWithToken("/api/channels/info", &ChannelsInfoResp{}, token)
+				result5 := resp5.Result().(*ChannelsInfoResp)
+
+				compareChannelsInfoBlockCount(result4, result5, "commonchannel", 1)
+				compareChannelsInfoBlockCount(result4, result5, "org2channel", 0)
+				compareChannelsInfoTxCount(result4, result5, "commonchannel", 1)
+				compareChannelsInfoTxCount(result4, result5, "org2channel", 0)
 			})
-
-			It("Should create a new event hub for the newly added channel within 60s", func() {
-				channelMonitored = "channel2422422422422422422422422422422422422422422422422422422422422422422422422422422422422422422422422422422422422422422422422422422422422422422422422422422422422422422422422422422422422422422422422422422422422422422422422422422422422422422"
-				Eventually(CheckHowManyEventHubRegistered, 70, 5).Should(Equal(1))
-				channelMonitored = "commonchannel"
-				Expect(CheckHowManyEventHubRegistered()).Should(Equal(1))
-				channelMonitored = "org1channel"
-				Expect(CheckHowManyEventHubRegistered()).Should(Equal(1))
-			})
-
-			It("Should keep running fine even after removing one of orderer peers", func() {
-				StopNode("orderer0-ordererorg1")
-				Eventually(CheckIfSwitchedToNewOrderer, 60, 5).Should(Equal(1))
-				StopNode("orderer1-ordererorg1")
-				Eventually(CheckIfSwitchedToNewOrderer, 60, 5).Should(Equal(2))
-			})
-
 		})
 
-		XIt("stop explorer", func() {
+		Context("/api/block/(channelHash)/(blockHeight)", func() {
+
+			It("get block info for org1", func() {
+
+				resp1 := restPost("/auth/login", map[string]interface{}{"user": "admin", "password": "adminpw", "network": "org1-network"}, &LoginResponse{})
+				result1 := resp1.Result().(*LoginResponse)
+				token := result1.Token
+				Expect(result1.User.Message).Should(Equal("logged in"))
+
+				resp2 := restGetWithToken("/api/channels/info", &ChannelsInfoResp{}, token)
+				result2 := resp2.Result().(*ChannelsInfoResp)
+
+				channelGenesisHash := result2.getGenesisHash("org1channel")
+				latestBlockNum := result2.getBlockHeight("org1channel") - 1
+				Expect(len(channelGenesisHash)).ShouldNot(Equal(0))
+
+				resp3 := restGetWithToken("/api/block/"+channelGenesisHash+"/"+strconv.Itoa(latestBlockNum), &BlockResp{}, token)
+				result3 := resp3.Result().(*BlockResp)
+				Expect(result3.Status).Should(Equal(200))
+				Expect(strconv.Atoi(result3.Number)).Should(Equal(latestBlockNum))
+				Expect(len(result3.Transactions)).Should(Equal(1))
+
+				channelGenesisHash = result2.getGenesisHash("commonchannel")
+				latestBlockNum = result2.getBlockHeight("commonchannel") - 1
+				Expect(len(channelGenesisHash)).ShouldNot(Equal(0))
+
+				resp3 = restGetWithToken("/api/block/"+channelGenesisHash+"/"+strconv.Itoa(latestBlockNum), &BlockResp{}, token)
+				result3 = resp3.Result().(*BlockResp)
+				Expect(result3.Status).Should(Equal(200))
+				Expect(strconv.Atoi(result3.Number)).Should(Equal(latestBlockNum))
+				Expect(len(result3.Transactions)).Should(Equal(1))
+			})
+
+			It("get block info for org2", func() {
+
+				resp1 := restPost("/auth/login", map[string]interface{}{"user": "admin", "password": "adminpw", "network": "org2-network"}, &LoginResponse{})
+				result1 := resp1.Result().(*LoginResponse)
+				token := result1.Token
+				Expect(result1.User.Message).Should(Equal("logged in"))
+
+				resp2 := restGetWithToken("/api/channels/info", &ChannelsInfoResp{}, token)
+				result2 := resp2.Result().(*ChannelsInfoResp)
+
+				channelGenesisHash := result2.getGenesisHash("org2channel")
+				latestBlockNum := result2.getBlockHeight("org2channel") - 1
+				Expect(len(channelGenesisHash)).ShouldNot(Equal(0))
+
+				resp3 := restGetWithToken("/api/block/"+channelGenesisHash+"/"+strconv.Itoa(latestBlockNum), &BlockResp{}, token)
+				result3 := resp3.Result().(*BlockResp)
+				Expect(result3.Status).Should(Equal(200))
+				Expect(strconv.Atoi(result3.Number)).Should(Equal(latestBlockNum))
+				Expect(len(result3.Transactions)).Should(Equal(1))
+
+				channelGenesisHash = result2.getGenesisHash("commonchannel")
+				latestBlockNum = result2.getBlockHeight("commonchannel") - 1
+				Expect(len(channelGenesisHash)).ShouldNot(Equal(0))
+
+				resp3 = restGetWithToken("/api/block/"+channelGenesisHash+"/"+strconv.Itoa(latestBlockNum), &BlockResp{}, token)
+				result3 = resp3.Result().(*BlockResp)
+				Expect(result3.Status).Should(Equal(200))
+				Expect(strconv.Atoi(result3.Number)).Should(Equal(latestBlockNum))
+				Expect(len(result3.Transactions)).Should(Equal(1))
+			})
+		})
+
+		// It("get status of peers within org2channel", func() {
+		// 	resp := restGetWithToken("/api/peersStatus/"+"org2channel", &PeersStatusResp{}, token)
+		// 	result := resp.Result().(*PeersStatusResp)
+		// 	Expect(result.Status).Should(Equal(200))
+		// })
+
+		// It("get block activity", func() {
+		// 	resp := restGetWithToken("/api/blockActivity/"+channelGenesisHash, &BlockActivityResp{}, token)
+		// 	result := resp.Result().(*BlockActivityResp)
+		// 	Expect(result.Status).Should(Equal(200))
+		// 	Expect(result.Row[0].Channelname).Should(Equal("org2channel"))
+		// 	org2CurrentBlockNum = result.Row[0].Blocknum
+		// })
+
+		// It("Update block on org1channel and should not have any changes on org2channel", func() {
+		// 	resp := restGetWithToken("/blockActivity/"+channelGenesisHash,&
+		// 	action = "invoke"
+		// 	inputSpecPath = "apitest-input-multiprofile-invoke-org1.yml"
+		// 	err := testclient.Testclient(action, inputSpecPath)
+		// 	Expect(err).NotTo(HaveOccurred())
+
+		// 	resp := restGetWithToken("/api/blockActivity/"+channelGenesisHash, &BlockActivityResp{}, token)
+		// 	result := resp.Result().(*BlockActivityResp)
+		// 	Expect(result.Status).Should(Equal(200))
+		// 	Expect(result.Row[0].Channelname).Should(Equal("org2channel"))
+		// 	Expect(result.Row[0].Blocknum).Should(Equal(org2CurrentBlockNum))
+		// })
+
+		// It("Update block on org2channel and should have some changes on org2channel", func() {
+		// 	action = "invoke"
+		// 	inputSpecPath = "apitest-input-multiprofile-invoke-org2.yml"
+		// 	err := testclient.Testclient(action, inputSpecPath)
+		// 	Expect(err).NotTo(HaveOccurred())
+
+		// 	resp := restGetWithToken("/api/blockActivity/"+channelGenesisHash, &BlockActivityResp{}, token)
+		// 	result := resp.Result().(*BlockActivityResp)
+		// 	Expect(result.Status).Should(Equal(200))
+		// 	Expect(result.Row[0].Channelname).Should(Equal("org2channel"))
+		// 	Expect(result.Row[0].Blocknum).Should(Equal(org2CurrentBlockNum + 1))
+		// })
+
+		// XIt("register user", func() {
+		// 	resp := restPostWithToken("/api/register", map[string]interface{}{"user": "test", "password": "test", "affiliation": "department2", "role": "admin"}, &RegisterResp{}, token)
+		// 	resultRegister := resp.Result().(*RegisterResp)
+		// 	Expect(resultRegister.Status).Should(Equal(200))
+		// })
+
+		// XIt("login with newly registered user", func() {
+		// 	resp := restPost("/auth/login", map[string]interface{}{"user": "test", "password": "test", "network": "org2-network"}, &LoginResponse{})
+		// 	resultLogin := resp.Result().(*LoginResponse)
+
+		// 	Expect(resultLogin.User.Message).Should(Equal("logged in"))
+		// 	Expect(resultLogin.User.Name).Should(Equal("test"))
+		// })
+
+		// XIt("fail to register duplicate user", func() {
+		// 	resp := restPostWithToken("/api/register", map[string]interface{}{"user": "test", "password": "test", "affiliation": "department2", "role": "admin"}, &RegisterResp{}, token)
+		// 	resultRegister := resp.Result().(*RegisterResp)
+		// 	Expect(resultRegister.Status).Should(Equal(400))
+		// 	Expect(resultRegister.Message).Should(Equal("Error: already exists"))
+		// })
+
+		It("stop explorer", func() {
 			_, err := networkclient.ExecuteCommand("./stopexplorer.sh", []string{}, true)
 			Expect(err).NotTo(HaveOccurred())
 		})
 
-		XIt("Shutdown network", func() {
+		It("Shutdown network", func() {
 			err := launcher.Launcher("down", "docker", "", networkSpecPath)
 			Expect(err).NotTo(HaveOccurred())
+
+			dockerList := []string{"ps", "-aq", "-f", "status=exited"}
+			containerList, _ := networkclient.ExecuteCommand("docker", dockerList, false)
+			if containerList != "" {
+				list := strings.Split(containerList, "\n")
+				containerArgs := []string{"rm", "-f"}
+				containerArgs = append(containerArgs, list...)
+				networkclient.ExecuteCommand("docker", containerArgs, true)
+			}
+			ccimagesList := []string{"images", "-q", "--filter=reference=dev*"}
+			images, _ := networkclient.ExecuteCommand("docker", ccimagesList, false)
+			if images != "" {
+				list := strings.Split(images, "\n")
+				imageArgs := []string{"rmi", "-f"}
+				imageArgs = append(imageArgs, list...)
+				networkclient.ExecuteCommand("docker", imageArgs, true)
+			}
 		})
 	})
 

--- a/app/platform/fabric/service/NetworkService.js
+++ b/app/platform/fabric/service/NetworkService.js
@@ -31,12 +31,15 @@ class NetworkService {
 		// Get the list of the networks from the  configuration that was loaded from the config.json
 		const networklist = [];
 		const networks = this.platform.getNetworks();
+		logger.debug('Network list ', networks);
 		const iterator = networks.entries();
 		for (const value of iterator) {
-			networklist.push(value);
+			const network_name = value[0];
+			logger.debug('Network list ', network_name);
+			networklist.push([network_name]);
 		}
 
-		logger.log('Network list ', networklist);
+		logger.debug('Network list ', networklist);
 		return networklist;
 	}
 }

--- a/app/platform/fabric/service/UserService.js
+++ b/app/platform/fabric/service/UserService.js
@@ -45,20 +45,16 @@ class UserService {
 		let adminPassword = null;
 		if (user.user && user.password && user.network) {
 			logger.log('user.network ', user.network);
-			const network = this.platform.getNetworks().get(user.network);
+			const clientObj = this.platform.getNetworks().get(user.network);
 
 			// TODO, need review maybe there is a better way to get the client config enableAuthentication
-			for (const [network_name, clients] of network.entries()) {
-				if (clients.config && clients.config.client) {
-					enableAuth = clients.config.client.enableAuthentication;
-					if (typeof enableAuth !== 'undefined' && enableAuth !== null) {
-						logger.info(
-							`Network: ${network_name} enableAuthentication ${enableAuth}`
-						);
-						adminUser = clients.config.client.adminUser;
-						adminPassword = clients.config.client.adminPassword;
-						break;
-					}
+			let client = clientObj.instance;
+			if (client.config && client.config.client) {
+				enableAuth = client.config.client.enableAuthentication;
+				if (typeof enableAuth !== 'undefined' && enableAuth !== null) {
+					logger.info(`Network: ${user.network} enableAuthentication ${enableAuth}`);
+					adminUser = client.config.client.adminUser;
+					adminPassword = client.config.client.adminPassword;
 				}
 			}
 
@@ -67,7 +63,8 @@ class UserService {
 				return {
 					authenticated: true,
 					user: user.user,
-					enableAuthentication: enableAuth
+					enableAuthentication: enableAuth,
+					network: user.network
 				};
 			}
 
@@ -76,7 +73,8 @@ class UserService {
 				return {
 					authenticated: true,
 					user: user.user,
-					enableAuthentication: enableAuth
+					enableAuthentication: enableAuth,
+					network: user.network
 				};
 			} else {
 				return {
@@ -276,10 +274,7 @@ class UserService {
 			fabricGw.gateway.disconnect();
 
 			// Connect to gateway
-			await fabricGw.gateway.connect(
-				fabricGw.config,
-				connectionOptions
-			);
+			await fabricGw.gateway.connect(fabricGw.config, connectionOptions);
 			logger.debug('Successfully reconnected with ', username);
 		} catch (err) {
 			throw new Error('Failed to reconnect: ' + err.toString());

--- a/app/platform/fabric/sync/SyncPlatform.js
+++ b/app/platform/fabric/sync/SyncPlatform.js
@@ -100,11 +100,14 @@ class SyncPlatform {
 
 		this.client = await FabricUtils.createFabricClient(
 			this.client_configs,
+			this.network_name,
 			this.client_name
 		);
 		if (!this.client) {
 			throw new ExplorerError(explorer_mess.error.ERROR_2011);
 		}
+
+		this.client.network_name = this.network_name;
 
 		// Updating the client network and other details to DB
 		const res = await this.syncService.synchNetworkConfigToDB(this.client);

--- a/app/platform/fabric/utils/FabricUtils.js
+++ b/app/platform/fabric/utils/FabricUtils.js
@@ -15,9 +15,14 @@ const helper = require('../../../common/helper');
 
 const logger = helper.getLogger('FabricUtils');
 
-async function createFabricClient(client_configs, client_name, persistence) {
+async function createFabricClient(
+	client_configs,
+	network_name,
+	client_name,
+	persistence
+) {
 	// Create new FabricClient
-	const client = new FabricClient(client_name);
+	const client = new FabricClient(network_name, client_name);
 	// Initialize fabric client
 	logger.debug(
 		'************ Initializing fabric client for [%s]************',
@@ -31,11 +36,16 @@ async function createFabricClient(client_configs, client_name, persistence) {
 	}
 }
 
-async function createDetachClient(client_configs, client_name, persistence) {
+async function createDetachClient(
+	client_configs,
+	network_name,
+	client_name,
+	persistence
+) {
 	// Clone global.hfc.config configuration
 	const client_config = cloneConfig(client_configs, client_name);
 
-	const client = new FabricClient(client_name);
+	const client = new FabricClient(network_name, client_name);
 	await client.initializeDetachClient(client_config, persistence);
 	return client;
 }

--- a/app/rest/platformroutes.js
+++ b/app/rest/platformroutes.js
@@ -25,7 +25,7 @@ const platformroutes = async function(router, platform) {
 
 		if (channel_genesis_hash) {
 			proxy
-				.getTxByOrgs(channel_genesis_hash)
+				.getTxByOrgs(req.network, channel_genesis_hash)
 				.then(rows => res.send({ status: 200, rows }));
 		} else {
 			return requtil.invalidRequest(req, res);
@@ -47,7 +47,7 @@ const platformroutes = async function(router, platform) {
 	 */
 	router.get('/channels/info', (req, res) => {
 		proxy
-			.getChannelsInfo()
+			.getChannelsInfo(req.network)
 			.then(data => {
 				data.forEach(element => {
 					element.createdat = new Date(element.createdat).toISOString();
@@ -72,7 +72,7 @@ const platformroutes = async function(router, platform) {
 	router.get('/peersStatus/:channel', (req, res) => {
 		const channelName = req.params.channel;
 		if (channelName) {
-			proxy.getPeersStatus(channelName).then(data => {
+			proxy.getPeersStatus(req.network, channelName).then(data => {
 				res.send({ status: 200, peers: data });
 			});
 		} else {
@@ -90,15 +90,17 @@ const platformroutes = async function(router, platform) {
 		const number = parseInt(req.params.number);
 		const channel_genesis_hash = req.params.channel_genesis_hash;
 		if (!isNaN(number) && channel_genesis_hash) {
-			proxy.getBlockByNumber(channel_genesis_hash, number).then(block => {
-				res.send({
-					status: 200,
-					number: block.header.number.toString(),
-					previous_hash: block.header.previous_hash,
-					data_hash: block.header.data_hash,
-					transactions: block.data.data
+			proxy
+				.getBlockByNumber(req.network, channel_genesis_hash, number)
+				.then(block => {
+					res.send({
+						status: 200,
+						number: block.header.number.toString(),
+						previous_hash: block.header.previous_hash,
+						data_hash: block.header.data_hash,
+						transactions: block.data.data
+					});
 				});
-			});
 		} else {
 			return requtil.invalidRequest(req, res);
 		}
@@ -118,7 +120,7 @@ const platformroutes = async function(router, platform) {
 	 * }
 	 */
 	router.get('/channels', (req, res) => {
-		proxy.getChannels().then(channels => {
+		proxy.getChannels(req.network).then(channels => {
 			const response = {
 				status: 200
 			};
@@ -133,7 +135,7 @@ const platformroutes = async function(router, platform) {
 	 * curl -i 'http://<host>:<port>/curChannel'
 	 */
 	router.get('/curChannel', (req, res) => {
-		proxy.getCurrentChannel().then(data => {
+		proxy.getCurrentChannel(req.network).then(data => {
 			res.send(data);
 		});
 	});
@@ -145,35 +147,11 @@ const platformroutes = async function(router, platform) {
 	 */
 	router.get('/changeChannel/:channel_genesis_hash', (req, res) => {
 		const channel_genesis_hash = req.params.channel_genesis_hash;
-		proxy.changeChannel(channel_genesis_hash).then(data => {
+		proxy.changeChannel(req.network, channel_genesis_hash).then(data => {
 			res.send({
 				currentChannel: data
 			});
 		});
-	});
-
-	/**
-	 * *Peer Status List
-	 * GET /peerlist -> /peersStatus
-	 * curl -i 'http://<host>:<port>/peersStatus/<channel>'
-	 * Response:
-	 * [
-	 * {
-	 * 'requests': 'grpcs://127.0.0.1:7051',
-	 * 'server_hostname': 'peer0.org1.example.com'
-	 * }
-	 * ]
-	 */
-
-	router.get('/peersStatus/:channel', (req, res) => {
-		const channelName = req.params.channel;
-		if (channelName) {
-			proxy.getPeersStatus(channelName).then(data => {
-				res.send({ status: 200, peers: data });
-			});
-		} else {
-			return requtil.invalidRequest(req, res);
-		}
 	});
 }; // End platformroutes()
 

--- a/app/rest/platformroutes.js
+++ b/app/rest/platformroutes.js
@@ -93,13 +93,17 @@ const platformroutes = async function(router, platform) {
 			proxy
 				.getBlockByNumber(req.network, channel_genesis_hash, number)
 				.then(block => {
-					res.send({
-						status: 200,
-						number: block.header.number.toString(),
-						previous_hash: block.header.previous_hash,
-						data_hash: block.header.data_hash,
-						transactions: block.data.data
-					});
+					if (typeof block === 'string') {
+						res.send({ status: 500, error: block });
+					} else {
+						res.send({
+							status: 200,
+							number: block.header.number.toString(),
+							previous_hash: block.header.previous_hash,
+							data_hash: block.header.data_hash,
+							transactions: block.data.data
+						});
+					}
 				});
 		} else {
 			return requtil.invalidRequest(req, res);

--- a/ci/azure-pipelines.yml
+++ b/ci/azure-pipelines.yml
@@ -3,6 +3,8 @@
 name: $(SourceBranchName)-$(Date:yyyyMMdd)$(Rev:.rrr)
 trigger:
 - master
+pr:
+- master
 
 variables:
   GOPATH: $(Agent.BuildDirectory)/go

--- a/client/e2e-test/docker-compose-explorer.yaml
+++ b/client/e2e-test/docker-compose-explorer.yaml
@@ -24,7 +24,6 @@ services:
       - DATABASE_USERNAME=hppoc
       - DATABASE_PASSWORD=password
     volumes:
-      - ./../../app/persistence/fabric/postgreSQL/db/createdb.sh:/docker-entrypoint-initdb.d/createdb.sh
       - pgdata:/var/lib/postgresql/data
     networks:
       - mynetwork.com

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -29,7 +29,6 @@ services:
       timeout: 10s
       retries: 5
     volumes:
-      - ./app/persistence/fabric/postgreSQL/db/createdb.sh:/docker-entrypoint-initdb.d/createdb.sh
       - pgdata:/var/lib/postgresql/data
     networks:
       - mynetwork.com

--- a/examples/net1/config.json
+++ b/examples/net1/config.json
@@ -1,7 +1,7 @@
 {
 	"network-configs": {
 		"first-network": {
-			"name": "firstnetwork",
+			"name": "first-network",
 			"profile": "./connection-profile/first-network.json"
 		}
 	},

--- a/postgres-Dockerfile
+++ b/postgres-Dockerfile
@@ -23,7 +23,7 @@ RUN apk update \
 WORKDIR /opt
 
 # Copy files
-COPY app/persistence/fabric/postgreSQL/db/explorerpg.sql 	/opt/explorerpg.sql
-COPY app/persistence/fabric/postgreSQL/db/updatepg.sql 	    /opt/updatepg.sql
-COPY app/persistence/fabric/postgreSQL/db/createdb.sh   	/opt/createdb.sh
-COPY app/persistence/fabric/postgreSQL/db/processenv.js   	/opt/processenv.js
+COPY app/persistence/fabric/postgreSQL/db/explorerpg.sql  /opt/explorerpg.sql
+COPY app/persistence/fabric/postgreSQL/db/updatepg.sql    /opt/updatepg.sql
+COPY app/persistence/fabric/postgreSQL/db/createdb.sh     /docker-entrypoint-initdb.d/createdb.sh
+COPY app/persistence/fabric/postgreSQL/db/processenv.js   /opt/processenv.js


### PR DESCRIPTION
In one single explorer instance, enable to handle multiple network profiles.

In this implementation, explorer make each profile isolated in single db(fabricexplorer) by adding its profile name to each record on DB.

https://jira.hyperledger.org/browse/BE-730