### PR TITLE
BE-738 Update info regarding required environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ blockchain-explorer
 # 3.0 Dependencies    <!-- do not remove this comment, ensure there is a blank line before each heading -->
 
 Following are the software dependencies required to install and run hyperledger explorer:
-* Nodejs 10.19+
+* Nodejs 10 and 12 (10.19 and 12.16 tested)
 * PostgreSQL 9.5 or greater
 * [jq](https://stedolan.github.io/jq)
 * Linux-based operating system, such as Ubuntu or MacOS

--- a/package.json
+++ b/package.json
@@ -8,10 +8,6 @@
 		"fabric-client sample app",
 		"v1.4.0 fabric nodesdk sample"
 	],
-	"engines": {
-		"node": "^8.11.2",
-		"npm": "^5.10.0"
-	},
 	"dependencies": {
 		"ajv": "^5.5.2",
 		"app-root-path": "^2.0.1",


### PR DESCRIPTION
Aligned the range of supported Node.js version with the range of fabric SDK packages
https://hyperledger.github.io/fabric-sdk-node/release-1.4/#toc4__anchor

Signed-off-by: Atsushi Neki <atsushin@fast.au.fujitsu.com>