### PR TITLE
[BE-741] Remove fullpath option with function

### DIFF
--- a/TROUBLESHOOT.md
+++ b/TROUBLESHOOT.md
@@ -741,7 +741,6 @@ adminPrivateKeyPath  /Users/USER_ID/workspace/fabric-1.3/fabric-samples/balance-
     organizations:
     { Org1MSP:
         { mspid: 'Org1MSP',
-            fullpath: true,
             adminPrivateKey: [Object],
             signedCert: [Object] } },
     peers:
@@ -901,7 +900,6 @@ adminPrivateKeyPath  /Users/USER_ID/workspace/fabric-1.3/fabric-samples/balance-
     organizations:
     { Org1MSP:
         { mspid: 'Org1MSP',
-            fullpath: true,
             adminPrivateKey: [Object],
             signedCert: [Object] } },
     peers:

--- a/app/platform/fabric/Platform.js
+++ b/app/platform/fabric/Platform.js
@@ -95,15 +95,7 @@ class Platform {
 
 		// Setting organization enrolment files
 		logger.debug('Setting admin organization enrolment files');
-		try {
-			this.network_configs = await FabricUtils.setAdminEnrolmentPath(
-				network_configs
-			);
-		} catch (e) {
-			logger.error(e);
-			clientstatus = false;
-			this.network_configs = network_configs;
-		}
+		this.network_configs = network_configs;
 
 		for (const network_name in this.network_configs) {
 			// this.networks.set(network_name, new Map());

--- a/app/platform/fabric/connection-profile/first-network.json
+++ b/app/platform/fabric/connection-profile/first-network.json
@@ -36,7 +36,6 @@
 	"organizations": {
 		"Org1MSP": {
 			"mspid": "Org1MSP",
-			"fullpath": true,
 			"adminPrivateKey": {
 				"path": "/fabric-path/fabric-samples/first-network/crypto-config/peerOrganizations/org1.example.com/users/Admin@org1.example.com/msp/keystore/1bebc656f198efb4b5bed08ef42cf3b2d89ac86f0a6b928e7a172fd823df0a48_sk"
 			},

--- a/app/platform/fabric/e2e-test/configs/connection-profile/org1-network.json
+++ b/app/platform/fabric/e2e-test/configs/connection-profile/org1-network.json
@@ -36,7 +36,6 @@
 	"organizations": {
 		"org1": {
 			"mspid": "Org1ExampleCom",
-			"fullpath": true,
 			"adminPrivateKey": {
 				"path": "./app/platform/fabric/e2e-test/specs/crypto-config/peerOrganizations/org1/users/Admin@org1/msp/keystore/priv_sk"
 			},

--- a/app/platform/fabric/e2e-test/configs/connection-profile/org2-network.json
+++ b/app/platform/fabric/e2e-test/configs/connection-profile/org2-network.json
@@ -36,7 +36,6 @@
 	"organizations": {
 		"org2": {
 			"mspid": "Org2ExampleCom",
-			"fullpath": true,
 			"adminPrivateKey": {
 				"path": "./app/platform/fabric/e2e-test/specs/crypto-config/peerOrganizations/org2/users/Admin@org2/msp/keystore/priv_sk"
 			},

--- a/app/platform/fabric/sync/SyncPlatform.js
+++ b/app/platform/fabric/sync/SyncPlatform.js
@@ -94,9 +94,7 @@ class SyncPlatform {
 		global.hfc.config.set('discovery-cache-life', this.blocksSyncTime);
 		global.hfc.config.set('initialize-with-discovery', true);
 
-		const client_configs = network_configs[this.network_name];
-
-		this.client_configs = await FabricUtils.setOrgEnrolmentPath(client_configs);
+		this.client_configs = network_configs[this.network_name];
 
 		this.client = await FabricUtils.createFabricClient(
 			this.client_configs,

--- a/app/platform/fabric/utils/FabricUtils.js
+++ b/app/platform/fabric/utils/FabricUtils.js
@@ -98,75 +98,6 @@ function processTLS_URL(client_config) {
 /**
  *
  *
- * @param {*} network_configs
- * @returns
- */
-async function setAdminEnrolmentPath(network_configs) {
-	for (const network_name in network_configs) {
-		network_configs[network_name] = setOrgEnrolmentPath(
-			network_configs[network_name]
-		);
-	}
-	return network_configs;
-}
-
-/**
- *
- *
- * @param {*} network_config
- * @returns
- */
-function setOrgEnrolmentPath(network_config) {
-	if (network_config && network_config.organizations) {
-		for (const organization_name in network_config.organizations) {
-			/*
-			 * Checking files path is defined as full path or directory
-			 * If directory, then it will consider the first file
-			 */
-			const organization = network_config.organizations[organization_name];
-			if (!organization.fullpath) {
-				// Setting admin private key as first file from keystore dir
-				logger.debug(
-					'Organization [%s] enrolment files path defined as directory',
-					organization_name
-				);
-				if (organization.adminPrivateKey) {
-					const privateKeyPath = organization.adminPrivateKey.path;
-					try {
-						const files = fs.readdirSync(privateKeyPath);
-						if (files && files.length > 0) {
-							organization.adminPrivateKey.path = path.join(privateKeyPath, files[0]);
-						}
-					} catch (err) {
-						logger.error(err);
-					}
-				}
-				// Setting admin private key as first file from signcerts dir
-				if (organization.signedCert) {
-					const signedCertPath = organization.signedCert.path;
-					try {
-						const files = fs.readdirSync(signedCertPath);
-						if (files && files.length > 0) {
-							organization.signedCert.path = path.join(signedCertPath, files[0]);
-						}
-					} catch (err) {
-						logger.error(err);
-					}
-				}
-			} else {
-				logger.debug(
-					'Organization [%s] enrolment files path defined as full path',
-					organization_name
-				);
-			}
-		}
-	}
-	return network_config;
-}
-
-/**
- *
- *
  * @param {*} dateStr
  * @returns
  */
@@ -259,8 +190,6 @@ function readFileSync(config_path) {
 	}
 }
 
-exports.setAdminEnrolmentPath = setAdminEnrolmentPath;
-exports.setOrgEnrolmentPath = setOrgEnrolmentPath;
 exports.generateBlockHash = generateBlockHash;
 exports.createFabricClient = createFabricClient;
 exports.getBlockTimeStamp = getBlockTimeStamp;

--- a/client/e2e-test/configs/connection-profile/org1-network-for-guitest.json
+++ b/client/e2e-test/configs/connection-profile/org1-network-for-guitest.json
@@ -36,7 +36,6 @@
 	"organizations": {
 		"org1": {
 			"mspid": "Org1ExampleCom",
-			"fullpath": true,
 			"adminPrivateKey": {
 				"path": "GOPATH/src/github.com/hyperledger/fabric-test/tools/operator/crypto-config/peerOrganizations/org1/users/Admin@org1/msp/keystore/priv_sk"
 			},

--- a/examples/net1/README.md
+++ b/examples/net1/README.md
@@ -110,7 +110,6 @@ A complete configuration **example** file is shown below for 2 ORG Blockchain in
       "organizations": {
         "Org1MSP": {
           "mspid": "Org1MSP",
-          "fullpath": false,
           "adminPrivateKey": {
             "path":
               "/tmp/crypto/peerOrganizations/org1.example.com/users/Admin@org1.example.com/msp/keystore"
@@ -237,7 +236,6 @@ Note: Make sure you put the right node IPs, ports and certs paths before running
       "organizations": {
         "Org1MSP": {
           "mspid": "Org1MSP",
-          "fullpath": false,
           "adminPrivateKey": {
             "path":
               "/tmp/crypto/peerOrganizations/org1.example.com/users/Admin@org1.example.com/msp/keystore"

--- a/examples/net1/connection-profile/first-network.json
+++ b/examples/net1/connection-profile/first-network.json
@@ -35,7 +35,6 @@
 	"organizations": {
 		"Org1MSP": {
 			"mspid": "Org1MSP",
-			"fullpath": true,
 			"adminPrivateKey": {
 				"path": "/tmp/crypto/peerOrganizations/org1.example.com/users/Admin@org1.example.com/msp/keystore/d30992c2b7799bc5c65bf6e4839369c7dd3edf0b786eecd4a9d3a3b207d8863f_sk"
 			},


### PR DESCRIPTION
The `network_config` comming into `setAminEnrolmentPath` and `setEnrolmentPath` are not used beacuse they do not actually have `organizations`.
Therefore, `fullpath` is an unnecessary option.
Delete everything related to the `fullpath`.

Signed-off-by: Sol Kang <pdpxpd@gmail.com>