### PR TITLE
Fix variable position in logger

### DIFF
--- a/app/platform/fabric/Platform.js
+++ b/app/platform/fabric/Platform.js
@@ -130,7 +130,7 @@ class Platform {
 			}
 
 			// Create client instance
-			logger.debug('Creating client [%s] >> ', client_configs, client_name);
+			logger.debug('Creating client [%s] >> ', client_name, client_configs);
 
 			let client;
 


### PR DESCRIPTION
The name and the position of the object are reversed and this is not displayed properly.

Signed-off-by: Sol Kang <pdpxpd@gmail.com>