### PR TITLE
BE-743 Fix segfault in Explorer container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-FROM node:10.19-alpine
+FROM node:10.19-alpine3.9
 
 # default values pf environment variables
 # that are used inside container


### PR DESCRIPTION
Chnaged alpine versin of node base image from 3.11 to 3.9

Signed-off-by: Atsushi Neki <atsushin@fast.au.fujitsu.com>

https://jira.hyperledger.org/browse/BE-743
