### PR TITLE
Making Hyperledger Explorer compatible to Amazon Managed Blockchain Network

### DIFF
--- a/app/persistence/fabric/postgreSQL/db/explorerpg.sql
+++ b/app/persistence/fabric/postgreSQL/db/explorerpg.sql
@@ -105,12 +105,12 @@ CREATE TABLE peer
   id SERIAL PRIMARY KEY,
   org integer DEFAULT NULL,
   channel_genesis_hash character varying(256) DEFAULT NULL,
-  mspid varchar(64) DEFAULT NULL,
-  requests varchar(64) DEFAULT NULL,
-  events varchar(64) DEFAULT NULL,
-  server_hostname varchar(64) DEFAULT NULL,
+  mspid varchar(256) DEFAULT NULL,
+  requests varchar(256) DEFAULT NULL,
+  events varchar(256) DEFAULT NULL,
+  server_hostname varchar(256) DEFAULT NULL,
   createdt timestamp DEFAULT NULL,
-  peer_type character varying(64) DEFAULT NULL,
+  peer_type character varying(256) DEFAULT NULL,
   network_name varchar(255)
 );
 ALTER table peer owner to :user;

--- a/app/persistence/fabric/postgreSQL/db/explorerpg.sql
+++ b/app/persistence/fabric/postgreSQL/db/explorerpg.sql
@@ -59,9 +59,9 @@ DROP TABLE IF EXISTS peer_ref_chaincode;
 CREATE TABLE peer_ref_chaincode
 (
   id SERIAL PRIMARY KEY,
-  peerid varchar(64) DEFAULT NULL,
-  chaincodeid varchar(64) DEFAULT NULL,
-  cc_version varchar(64) DEFAULT NULL,
+  peerid varchar(256) DEFAULT NULL,
+  chaincodeid varchar(255) DEFAULT NULL,
+  cc_version varchar(255) DEFAULT NULL,
   channelid character varying(256) DEFAULT NULL,
   createdt Timestamp DEFAULT NULL,
   network_name varchar(255)
@@ -87,7 +87,7 @@ CREATE TABLE channel
   channel_config bytea default NULL,
   channel_block bytea DEFAULT NULL,
   channel_tx bytea DEFAULT NULL,
-  channel_version character varying(128) DEFAULT NULL,
+  channel_version character varying(256) DEFAULT NULL,
   network_name varchar(255)
 );
 
@@ -123,9 +123,9 @@ CREATE TABLE peer_ref_channel
 (
   id SERIAL PRIMARY KEY,
   createdt Timestamp DEFAULT NULL,
-  peerid varchar(64),
+  peerid varchar(256),
   channelid character varying(256),
-  peer_type character varying(64) DEFAULT NULL,
+  peer_type character varying(256) DEFAULT NULL,
   network_name varchar(255)
 );
 ALTER table peer_ref_channel owner to :user;
@@ -141,8 +141,8 @@ DROP TABLE IF EXISTS orderer;
 CREATE TABLE orderer
 (
   id SERIAL PRIMARY KEY,
-  requests varchar(64) DEFAULT NULL,
-  server_hostname varchar(64) DEFAULT NULL,
+  requests varchar(256) DEFAULT NULL,
+  server_hostname varchar(256) DEFAULT NULL,
   createdt timestamp DEFAULT NULL,
   network_name varchar(255)
 );
@@ -161,14 +161,14 @@ CREATE TABLE transactions
   createdt timestamp DEFAULT NULL,
   chaincodename character varying(255) DEFAULT NULL,
   status integer DEFAULT NULL,
-  creator_msp_id character varying(128) DEFAULT NULL,
+  creator_msp_id character varying(256) DEFAULT NULL,
   endorser_msp_id character varying(800) DEFAULT NULL,
   chaincode_id character varying(256) DEFAULT NULL,
-  type character varying(128) DEFAULT NULL,
+  type character varying(256) DEFAULT NULL,
   read_set json default NULL,
   write_set json default NULL,
   channel_genesis_hash character varying(256) DEFAULT NULL,
-  validation_code character varying(50) DEFAULT NULL,
+  validation_code character varying(255) DEFAULT NULL,
   envelope_signature character varying DEFAULT NULL,
   payload_extension character varying DEFAULT NULL,
   creator_id_bytes character varying DEFAULT NULL,


### PR DESCRIPTION
it is common that peer names in amazon managed blockchain network will be long alphanumeric strings. so, database rows length should be set high to make explorer to compatible for Amazon managed blockchain.
[Jira Discussion](https://jira.hyperledger.org/browse/BE-744)

Signed-off by Salmandabbakuti <Salmandabbakuti@github.com>