### PR TITLE
[BE-742] Fix return value about getOrganizationsConfig

### DIFF
--- a/app/platform/fabric/FabricConfig.js
+++ b/app/platform/fabric/FabricConfig.js
@@ -63,6 +63,16 @@ class FabricConfig {
 	 * @returns
 	 * @memberof FabricConfig
 	 */
+	getOrganization() {
+		return this.config.client.organization;
+	}
+
+	/**
+	 *
+	 *
+	 * @returns
+	 * @memberof FabricConfig
+	 */
 	getTls() {
 		logger.info('config.client.tlsEnable ', this.config.client.tlsEnable);
 		return this.config.client.tlsEnable;
@@ -172,20 +182,12 @@ class FabricConfig {
 	 * @memberof FabricConfig
 	 */
 	getOrganizationsConfig() {
-		const orgMsp = [];
-		let adminPrivateKeyPath;
-		let signedCertPath;
-		for (const x in this.config.organizations) {
-			if (this.config.organizations[x].mspid) {
-				orgMsp.push(this.config.organizations[x].mspid);
-			}
-			if (this.config.organizations[x].adminPrivateKey) {
-				adminPrivateKeyPath = this.config.organizations[x].adminPrivateKey.path;
-			}
-			if (this.config.organizations[x].signedCert) {
-				signedCertPath = this.config.organizations[x].signedCert.path;
-			}
-		}
+		const organization = this.config.organizations[this.getOrganization()];
+
+		const orgMsp = organization.mspid;
+		const adminPrivateKeyPath = organization.adminPrivateKey.path;
+		const signedCertPath = organization.signedCert.path;
+
 		return { orgMsp, adminPrivateKeyPath, signedCertPath };
 	}
 

--- a/app/platform/fabric/gateway/FabricGateway.js
+++ b/app/platform/fabric/gateway/FabricGateway.js
@@ -80,7 +80,7 @@ class FabricGateway {
 		);
 
 		this.defaultChannelName = this.fabricConfig.getDefaultChannel();
-		this.mspId = orgMsp[0];
+		this.mspId = orgMsp;
 		let caURL = [];
 		let serverCertPath = null;
 		({ caURL, serverCertPath } = this.fabricConfig.getCertificateAuthorities());

--- a/app/platform/fabric/gateway/FabricGateway.js
+++ b/app/platform/fabric/gateway/FabricGateway.js
@@ -62,7 +62,7 @@ class FabricGateway {
 		const peers = this.fabricConfig.getPeers();
 		this.defaultPeer = peers[0].name;
 		this.defaultPeerUrl = peers[0].url;
-		let orgMsp = [];
+		let orgMsp;
 		let signedCertPath;
 		let adminPrivateKeyPath;
 		logger.log('========== > defaultPeer ', this.defaultPeer);


### PR DESCRIPTION
* I changed return value to return only one organization
* Standard of return value is the value in config.client.organization

Signed-off-by: 5pecia1 <pdpxpd@gmail.com>