### PR TITLE
BE-746 Implement queryChannels by invoke "GetChannels" func in CSCC

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -431,7 +431,7 @@
 					"guitest",
 					"configfiles"
 				],
-				"skipIfMatch": ["http://[^s]*"],
+				"skipIfMatch": ["http://[^s]*", "[a-z]scc"],
 				"skipWordIfMatch": ["^foobar.*$"],
 				"minLength": 3
 			}

--- a/app/platform/fabric/FabricClient.js
+++ b/app/platform/fabric/FabricClient.js
@@ -108,7 +108,7 @@ class FabricClient {
 		let channels;
 		try {
 			logger.debug('this.defaultPeer ', this.defaultPeer);
-			channels = await this.hfc_client.queryChannels(this.defaultPeer, true);
+			channels = await this.fabricGateway.queryChannels();
 		} catch (e) {
 			logger.error(e);
 		}

--- a/app/platform/fabric/gateway/FabricGateway.js
+++ b/app/platform/fabric/gateway/FabricGateway.js
@@ -4,6 +4,7 @@
 
 const { Wallets, Gateway } = require('fabric-network');
 const { Client } = require('fabric-common');
+const fabprotos = require('fabric-protos');
 
 const FabricCAServices = require('fabric-ca-client');
 
@@ -251,6 +252,17 @@ class FabricGateway {
 			logger.error(error);
 		}
 		return identityInfo;
+	}
+
+	async queryChannels() {
+		const network = await this.gateway.getNetwork(this.defaultChannelName);
+
+		// Get the contract from the network.
+		const contract = network.getContract('cscc');
+		const result = await contract.evaluateTransaction('GetChannels');
+		const resultJson = fabprotos.protos.ChannelQueryResponse.decode(result);
+		logger.info('queryChannels :', resultJson);
+		return resultJson;
 	}
 }
 

--- a/app/platform/fabric/sync/FabricEvent.js
+++ b/app/platform/fabric/sync/FabricEvent.js
@@ -186,9 +186,7 @@ class FabricEvent {
 	 */
 	async synchBlocks() {
 		// getting all channels list from client ledger
-		const channels = await this.client
-			.getHFC_Client()
-			.queryChannels(this.client.getDefaultPeer().getName(), true);
+		const channels = await this.client.fabricGateway.queryChannels();
 
 		for (const channel of channels.channels) {
 			const channel_name = channel.channel_id;

--- a/app/platform/fabric/sync/SyncService.js
+++ b/app/platform/fabric/sync/SyncService.js
@@ -60,10 +60,7 @@ class SyncServices {
 	 */
 	async synchNetworkConfigToDB(client) {
 		const channels = client.getChannels();
-		const channels_query = await client.hfc_client.queryChannels(
-			client.defaultPeer,
-			true
-		);
+		const channels_query = await client.fabricGateway.queryChannels();
 		for (const channel of channels_query.channels) {
 			const channel_name = channel.channel_id;
 			if (!channels.get(channel_name)) {


### PR DESCRIPTION
The function for querying channels to fabric network has not been supported in the sdk for fabric v2.x. So we need to implement this function by accessing fabric network directly.

This PR will change to use configuration system chaincode to query channels that specified peer is joining.

Signed-off-by: Atsushi Neki <atsushin@fast.au.fujitsu.com>