### PR TITLE
Implement queryBlock by using system chaincode for query (qscc)

### DIFF
--- a/app/platform/fabric/FabricClient.js
+++ b/app/platform/fabric/FabricClient.js
@@ -788,6 +788,21 @@ class FabricClient {
 	/**
 	 *
 	 *
+	 * @param {*} channel_genesis_hash
+	 * @returns
+	 * @memberof FabricClient
+	 */
+	getChannelNameByHash(channel_genesis_hash) {
+		for (const [channel_name, hash_name] of this.channelsGenHash.entries()) {
+			if (channel_genesis_hash === hash_name) {
+				return channel_name;
+			}
+		}
+	}
+
+	/**
+	 *
+	 *
 	 * @param {*} channel_name
 	 * @returns
 	 * @memberof FabricClient

--- a/app/platform/fabric/Proxy.js
+++ b/app/platform/fabric/Proxy.js
@@ -235,15 +235,11 @@ class Proxy {
 	 */
 	async getBlockByNumber(network_name, channel_genesis_hash, number) {
 		const client = this.platform.getClient(network_name);
-		const channel = client.getChannelByHash(channel_genesis_hash);
+		const channelName = client.getChannelNameByHash(channel_genesis_hash);
 		let block;
 
 		try {
-			block = await channel.queryBlock(
-				parseInt(number),
-				client.getDefaultPeer(),
-				true
-			);
+			block = await client.fabricGateway.queryBlock(channelName, parseInt(number));
 		} catch (e) {
 			logger.debug('queryBlock >> ', e);
 		}

--- a/app/platform/fabric/gateway/FabricGateway.js
+++ b/app/platform/fabric/gateway/FabricGateway.js
@@ -3,7 +3,7 @@
  */
 
 const { Wallets, Gateway } = require('fabric-network');
-const { Client } = require('fabric-common');
+const { BlockDecoder, Client } = require('fabric-common');
 const fabprotos = require('fabric-protos');
 
 const FabricCAServices = require('fabric-ca-client');
@@ -262,6 +262,21 @@ class FabricGateway {
 		const result = await contract.evaluateTransaction('GetChannels');
 		const resultJson = fabprotos.protos.ChannelQueryResponse.decode(result);
 		logger.info('queryChannels :', resultJson);
+		return resultJson;
+	}
+
+	async queryBlock(channelName, blockNum) {
+		const network = await this.gateway.getNetwork(this.defaultChannelName);
+
+		// Get the contract from the network.
+		const contract = network.getContract('qscc');
+		const resultByte = await contract.evaluateTransaction(
+			'GetBlockByNumber',
+			channelName,
+			String(blockNum)
+		);
+		const resultJson = BlockDecoder.decode(resultByte);
+		logger.info('queryBlock :', resultJson);
 		return resultJson;
 	}
 }

--- a/app/platform/fabric/gateway/FabricGateway.js
+++ b/app/platform/fabric/gateway/FabricGateway.js
@@ -261,7 +261,6 @@ class FabricGateway {
 		const contract = network.getContract('cscc');
 		const result = await contract.evaluateTransaction('GetChannels');
 		const resultJson = fabprotos.protos.ChannelQueryResponse.decode(result);
-		logger.info('queryChannels :', resultJson);
 		return resultJson;
 	}
 
@@ -276,7 +275,6 @@ class FabricGateway {
 			String(blockNum)
 		);
 		const resultJson = BlockDecoder.decode(resultByte);
-		logger.info('queryBlock :', resultJson);
 		return resultJson;
 	}
 }

--- a/app/platform/fabric/sync/SyncService.js
+++ b/app/platform/fabric/sync/SyncService.js
@@ -414,9 +414,6 @@ class SyncServices {
 		const _self = this;
 		// Get the first transaction
 		const first_tx = block.data.data[0];
-		logger.info('processBlockEvent: block ', block);
-		logger.info('processBlockEvent: block.data.data', block.data.data);
-		logger.info('processBlockEvent: first_tx ', first_tx);
 		// The 'header' object contains metadata of the transaction
 		const header = first_tx.payload.header;
 		const channel_name = header.channel_header.channel_id;

--- a/app/platform/fabric/sync/SyncService.js
+++ b/app/platform/fabric/sync/SyncService.js
@@ -388,10 +388,10 @@ class SyncServices {
 		if (results) {
 			for (const result of results) {
 				// Get block by number
-				const block = await client
-					.getHFC_Client()
-					.getChannel(channel_name)
-					.queryBlock(result.missing_id, client.getDefaultPeer(), true);
+				const block = await client.fabricGateway.queryBlock(
+					channel_name,
+					result.missing_id
+				);
 				await this.processBlockEvent(client, block);
 			}
 		} else {
@@ -414,6 +414,9 @@ class SyncServices {
 		const _self = this;
 		// Get the first transaction
 		const first_tx = block.data.data[0];
+		logger.info('processBlockEvent: block ', block);
+		logger.info('processBlockEvent: block.data.data', block.data.data);
+		logger.info('processBlockEvent: first_tx ', first_tx);
 		// The 'header' object contains metadata of the transaction
 		const header = first_tx.payload.header;
 		const channel_name = header.channel_header.channel_id;


### PR DESCRIPTION
The function for querying block to fabric network has not been supported in the sdk for fabric v2.x. So we need to implement this function by accessing fabric network directly.

This PR will change to use system chaincode for querying channel/block/transaction (qscc) of specified channel.