### PR TITLE
BE-752 Retrieve genesis block from peers, not orderer

### DIFF
--- a/app/platform/fabric/e2e-test/specs/apitest_test.go
+++ b/app/platform/fabric/e2e-test/specs/apitest_test.go
@@ -242,11 +242,6 @@ var _ = Describe("REST API Test Suite - Single profile", func() {
 				Expect(CheckHowManyEventHubRegistered()).Should(Equal(true))
 			})
 
-			It("Should keep running fine even after removing one of orderer peers", func() {
-				StopNode("orderer0-ordererorg1")
-				Eventually(CheckIfSwitchedToNewOrderer, 60, 5).Should(Equal(true))
-			})
-
 		})
 
 		It("stop explorer", func() {

--- a/app/platform/fabric/gateway/FabricGateway.js
+++ b/app/platform/fabric/gateway/FabricGateway.js
@@ -265,17 +265,25 @@ class FabricGateway {
 	}
 
 	async queryBlock(channelName, blockNum) {
-		const network = await this.gateway.getNetwork(this.defaultChannelName);
+		try {
+			const network = await this.gateway.getNetwork(this.defaultChannelName);
 
-		// Get the contract from the network.
-		const contract = network.getContract('qscc');
-		const resultByte = await contract.evaluateTransaction(
-			'GetBlockByNumber',
-			channelName,
-			String(blockNum)
-		);
-		const resultJson = BlockDecoder.decode(resultByte);
-		return resultJson;
+			// Get the contract from the network.
+			const contract = network.getContract('qscc');
+			const resultByte = await contract.evaluateTransaction(
+				'GetBlockByNumber',
+				channelName,
+				String(blockNum)
+			);
+			const resultJson = BlockDecoder.decode(resultByte);
+			return resultJson;
+		} catch (error) {
+			logger.error(
+				`Failed to get block ${blockNum} from channel ${channelName} : `,
+				error
+			);
+			return null;
+		}
 	}
 }
 

--- a/app/platform/fabric/sync/FabricEvent.js
+++ b/app/platform/fabric/sync/FabricEvent.js
@@ -187,6 +187,10 @@ class FabricEvent {
 	async synchBlocks() {
 		// getting all channels list from client ledger
 		const channels = await this.client.fabricGateway.queryChannels();
+		if (!channels) {
+			logger.error('Not found any channels');
+			return;
+		}
 
 		for (const channel of channels.channels) {
 			const channel_name = channel.channel_id;

--- a/app/platform/fabric/sync/SyncService.js
+++ b/app/platform/fabric/sync/SyncService.js
@@ -61,6 +61,11 @@ class SyncServices {
 	async synchNetworkConfigToDB(client) {
 		const channels = client.getChannels();
 		const channels_query = await client.fabricGateway.queryChannels();
+		if (!channels_query) {
+			logger.error('Not found any channels');
+			return false;
+		}
+
 		for (const channel of channels_query.channels) {
 			const channel_name = channel.channel_id;
 			if (!channels.get(channel_name)) {
@@ -75,7 +80,7 @@ class SyncServices {
 				' channel_name ',
 				channel_name
 			);
-			const block = await client.getGenesisBlock(channel);
+			const block = await client.getGenesisBlock(channel_name);
 			const channel_genesis_hash = await FabricUtils.generateBlockHash(
 				block.header
 			);
@@ -392,7 +397,9 @@ class SyncServices {
 					channel_name,
 					result.missing_id
 				);
-				await this.processBlockEvent(client, block);
+				if (block) {
+					await this.processBlockEvent(client, block);
+				}
 			}
 		} else {
 			logger.debug('Missing blocks not found for %s', channel_name);


### PR DESCRIPTION
Removed accesses to orderer for retrieving genesis block. Use queryBlock for it instead.

Signed-off-by: Atsushi Neki <atsushin@fast.au.fujitsu.com>