### PR TITLE
Fix PostgreSQL typo

### DIFF
--- a/app/persistence/postgreSQL/PgService.js
+++ b/app/persistence/postgreSQL/PgService.js
@@ -42,7 +42,7 @@ class PgService {
 		this.pgconfig.host = process.env.DATABASE_HOST || pgconfig.host;
 		this.pgconfig.port = process.env.DATABASE_PORT || pgconfig.port;
 		this.pgconfig.database = process.env.DATABASE_DATABASE || pgconfig.database;
-		this.pgconfig.user = process.env.DATABASE_USERNAME || pgconfig.username;
+		this.pgconfig.username = process.env.DATABASE_USERNAME || pgconfig.username;
 		this.pgconfig.password = process.env.DATABASE_PASSWD || pgconfig.passwd;
 
 		const isPostgresSslEnabled = process.env.DATABASE_SSL_ENABLED || false;


### PR DESCRIPTION
Explorer ignores environment variable passed through compose file. Cause this small typo.
```
[2020-06-07T16:02:28.399] [INFO] PgService - SSL to Postgresql disabled
[2020-06-07T16:02:28.401] [INFO] PgService - connecting to Postgresql postgres://hppoc:******@postgres:5432/somedb ### but I passed `postgres` user
```
Used tag: `latest`