### PR TITLE
Add configuration for SonarCloud to narrow focus

### DIFF
--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -1,0 +1,19 @@
+#
+#    SPDX-License-Identifier: Apache-2.0
+#
+
+# Path to sources
+sonar.sources=app/**/*,client/**/*
+sonar.exclusions=**/e2e-test/**
+#sonar.inclusions=
+
+# Path to tests
+#sonar.tests=
+#sonar.test.exclusions=
+#sonar.test.inclusions=
+
+# Source encoding
+#sonar.sourceEncoding=UTF-8
+
+# Exclusions for copy-paste detection
+#sonar.cpd.exclusions=


### PR DESCRIPTION
To exclude test files from focus of code analysis on SonarCloud.

https://sonarcloud.io/dashboard?id=hyperledger_blockchain-explorer

Signed-off-by: Atsushi Neki <atsushin@fast.au.fujitsu.com>