### PR TITLE
BE-756 Fix tx count in Chaincode view

### DIFF
--- a/app/platform/fabric/FabricClient.js
+++ b/app/platform/fabric/FabricClient.js
@@ -276,6 +276,12 @@ class FabricClient {
 			discover_results
 		);
 
+		if ('peers_by_org' in discover_results) {
+			for (const org in discover_results.peers_by_org) {
+				logger.info('Discovered', org, discover_results.peers_by_org[org].peers);
+			}
+		}
+
 		return discover_results;
 	}
 

--- a/app/platform/fabric/FabricConfig.js
+++ b/app/platform/fabric/FabricConfig.js
@@ -51,10 +51,22 @@ class FabricConfig {
 	 * @memberof FabricConfig
 	 */
 	isFabricCaEnabled() {
-		if (this.config.certificateAuthorities) {
-			return true;
+		if (this.config.certificateAuthorities === undefined) {
+			return false;
 		}
-		return false;
+
+		const org = this.getOrganization();
+		const caArray = this.config.organizations[org].certificateAuthorities;
+		if (caArray === undefined) {
+			return false;
+		}
+
+		const caName = caArray[0];
+		if (this.config.certificateAuthorities[caName] === undefined) {
+			return false;
+		}
+		logger.info('Fabric CA: Enabled');
+		return true;
 	}
 
 	/**

--- a/app/platform/fabric/Proxy.js
+++ b/app/platform/fabric/Proxy.js
@@ -125,6 +125,9 @@ class Proxy {
 				node.status = 'DOWN';
 				if (discover_results && discover_results.peers_by_org) {
 					const org = discover_results.peers_by_org[node.mspid];
+					if (org === undefined) {
+						continue;
+					}
 					for (const peer of org.peers) {
 						if (peer.endpoint.indexOf(node.server_hostname) > -1) {
 							node.ledger_height_low = peer.ledger_height.low;

--- a/app/platform/fabric/sync/SyncService.js
+++ b/app/platform/fabric/sync/SyncService.js
@@ -300,7 +300,10 @@ class SyncServices {
 		discoveryResults
 	) {
 		const network_name = client.network_name;
-		const chaincodes = await client.fabricGateway.queryInstantiatedChaincodes();
+		const channel_name = client.getChannelNameByHash(channel_genesis_hash);
+		const chaincodes = await client.fabricGateway.queryInstantiatedChaincodes(
+			channel_name
+		);
 		for (const chaincode of chaincodes.chaincodes) {
 			let path = '-';
 			if (chaincode.path !== undefined) {


### PR DESCRIPTION
In fabric v2.1.0, when updating txcount of chaincode in explorer, explorer figures out which records should be updated by channel name and chaincode name included in each transaction. Currently chaincode name on chaincodes table is including not only name but also version and ID. So explorer can't find any records to be updated when receiving transactions.

https://jira.hyperledger.org/browse/BE-756

Signed-off-by: Atsushi Neki <atsushin@fast.au.fujitsu.com>