### PR TITLE
BE-757 Disable CA server support

### DIFF
--- a/app/platform/fabric/e2e-test/specs/apitest_test.go
+++ b/app/platform/fabric/e2e-test/specs/apitest_test.go
@@ -170,13 +170,13 @@ var _ = Describe("REST API Test Suite - Single profile", func() {
 			Expect(result.Row[0].Channelname).Should(Equal("commonchannel"))
 		})
 
-		It("register user", func() {
+		XIt("register user", func() {
 			resp := restPostWithToken("/api/register", map[string]interface{}{"user": "test", "password": "test", "affiliation": "department2", "role": "admin"}, &RegisterResp{}, token)
 			resultRegister := resp.Result().(*RegisterResp)
 			Expect(resultRegister.Status).Should(Equal(200))
 		})
 
-		It("login with newly registered user", func() {
+		XIt("login with newly registered user", func() {
 			resp := restPost("/auth/login", map[string]interface{}{"user": "test", "password": "test", "network": "org1-network"}, &LoginResponse{})
 			resultLogin := resp.Result().(*LoginResponse)
 
@@ -184,7 +184,7 @@ var _ = Describe("REST API Test Suite - Single profile", func() {
 			Expect(resultLogin.User.Name).Should(Equal("test"))
 		})
 
-		It("fail to register duplicate user", func() {
+		XIt("fail to register duplicate user", func() {
 			resp := restPostWithToken("/api/register", map[string]interface{}{"user": "test", "password": "test", "affiliation": "department2", "role": "admin"}, &RegisterResp{}, token)
 			resultRegister := resp.Result().(*RegisterResp)
 			Expect(resultRegister.Status).Should(Equal(400))

--- a/app/platform/fabric/gateway/FabricGateway.js
+++ b/app/platform/fabric/gateway/FabricGateway.js
@@ -83,7 +83,6 @@ class FabricGateway {
 		);
 
 		this.defaultChannelName = this.fabricConfig.getDefaultChannel();
-		const caURLs = this.fabricConfig.getCertificateAuthorities();
 		/* eslint-enable */
 		let identity;
 		try {
@@ -95,11 +94,6 @@ class FabricGateway {
 			if (identity) {
 				logger.debug(
 					`An identity for the admin user: ${this.fabricConfig.getAdminUser()} already exists in the wallet`
-				);
-			} else if (this.fabricCaEnabled) {
-				identity = await this.enrollCaIdentity(
-					this.fabricConfig.getAdminUser(),
-					this.fabricConfig.getAdminPassword()
 				);
 			} else {
 				/*
@@ -305,7 +299,7 @@ class FabricGateway {
 		}
 		return resultJson;
 	}
-	
+
 	async queryChainInfo(channelName) {
 		try {
 			const network = await this.gateway.getNetwork(this.defaultChannelName);


### PR DESCRIPTION
When enabling CA server in network profile, admin certificate is retrieved from CA server instead of using the certificate specified in the network profile. But the certificate retrieved from CA server does not have admin priviledge so explorer running under the certificate fails to query chaincode on the network. Because the query to the installed chaincode is required admin policy by default. Our CA server support has been incomplete yet, so we'll disable this functionality temporarily.

https://jira.hyperledger.org/browse/BE-757

Signed-off-by: Atsushi Neki <atsushin@fast.au.fujitsu.com>