### PR TITLE
BE-773 Add Fabric CA support

### DIFF
--- a/app/platform/fabric/FabricClient.js
+++ b/app/platform/fabric/FabricClient.js
@@ -64,6 +64,7 @@ class FabricClient {
 		} catch (error) {
 			// TODO in case of the failure, should terminate explorer?
 			logger.error(error);
+			throw new ExplorerError(error);
 		}
 
 		// Getting channels from queryChannels

--- a/app/platform/fabric/FabricConfig.js
+++ b/app/platform/fabric/FabricConfig.js
@@ -107,7 +107,47 @@ class FabricConfig {
 	 * @memberof FabricConfig
 	 */
 	getAdminUser() {
-		return this.config.client.adminUser;
+		return this.config.client.adminCredential.id;
+	}
+
+	/**
+	 *
+	 *
+	 * @returns
+	 * @memberof FabricConfig
+	 */
+	getAdminPassword() {
+		return this.config.client.adminCredential.password;
+	}
+
+	/**
+	 *
+	 *
+	 * @returns
+	 * @memberof FabricConfig
+	 */
+	getAdminAffiliation() {
+		return this.config.client.adminCredential.affiliation;
+	}
+
+	/**
+	 *
+	 *
+	 * @returns
+	 * @memberof FabricConfig
+	 */
+	getCaAdminUser() {
+		return this.config.client.caCredential.id;
+	}
+
+	/**
+	 *
+	 *
+	 * @returns
+	 * @memberof FabricConfig
+	 */
+	getCaAdminPassword() {
+		return this.config.client.caCredential.password;
 	}
 
 	/**
@@ -118,16 +158,6 @@ class FabricConfig {
 	 */
 	getNetworkName() {
 		return this.config.name;
-	}
-
-	/**
-	 *
-	 *
-	 * @returns
-	 * @memberof FabricConfig
-	 */
-	getAdminPassword() {
-		return this.config.client.adminPassword;
 	}
 
 	/**
@@ -178,14 +208,20 @@ class FabricConfig {
 	 * @returns
 	 * @memberof FabricConfig
 	 */
-	getOrganizationsConfig() {
+	getOrgSignedCertPath() {
 		const organization = this.config.organizations[this.getOrganization()];
+		return organization.signedCert.path;
+	}
 
-		const orgMsp = organization.mspid;
-		const adminPrivateKeyPath = organization.adminPrivateKey.path;
-		const signedCertPath = organization.signedCert.path;
-
-		return { orgMsp, adminPrivateKeyPath, signedCertPath };
+	/**
+	 *
+	 *
+	 * @returns
+	 * @memberof FabricConfig
+	 */
+	getOrgAdminPrivateKeyPath() {
+		const organization = this.config.organizations[this.getOrganization()];
+		return organization.adminPrivateKey.path;
 	}
 
 	/**

--- a/app/platform/fabric/connection-profile/first-network.json
+++ b/app/platform/fabric/connection-profile/first-network.json
@@ -4,8 +4,15 @@
 	"license": "Apache-2.0",
 	"client": {
 		"tlsEnable": true,
-		"adminUser": "admin",
-		"adminPassword": "adminpw",
+		"caCredential": {
+			"id": "admin",
+			"password": "adminpw"
+		},
+		"adminCredential": {
+			"id": "exploreradmin",
+			"password": "exploreradminpw",
+			"affiliation": "org1.department1"
+		},
 		"enableAuthentication": true,
 		"organization": "Org1MSP",
 		"connection": {
@@ -54,6 +61,18 @@
 			"grpcOptions": {
 				"ssl-target-name-override": "peer0.org1.example.com"
 			}
+		}
+	},
+	"certificateAuthorities": {
+		"ca0": {
+			"url": "https://localhost:7054",
+			"httpOptions": {
+				"verify": false
+			},
+			"tlsCACerts": {
+				"path": "/fabric-path/fabric-samples/first-network/crypto-config/peerOrganizations/org1/ca/ca.org1-cert.pem"
+			},
+			"caName": "ca0-org1"
 		}
 	}
 }

--- a/app/platform/fabric/e2e-test/configs/connection-profile/org1-network.json
+++ b/app/platform/fabric/e2e-test/configs/connection-profile/org1-network.json
@@ -4,8 +4,15 @@
 	"license": "Apache-2.0",
 	"client": {
 		"tlsEnable": true,
-		"adminUser": "admin",
-		"adminPassword": "adminpw",
+		"caCredential": {
+			"id": "admin",
+			"password": "adminpw"
+		},
+		"adminCredential": {
+			"id": "exploreradmin",
+			"password": "exploreradminpw",
+			"affiliation": "org1.department1"
+		},
 		"enableAuthentication": false,
 		"organization": "org1",
 		"connection": {

--- a/app/platform/fabric/e2e-test/configs/connection-profile/org2-network.json
+++ b/app/platform/fabric/e2e-test/configs/connection-profile/org2-network.json
@@ -4,8 +4,15 @@
 	"license": "Apache-2.0",
 	"client": {
 		"tlsEnable": true,
-		"adminUser": "admin",
-		"adminPassword": "adminpw",
+		"caCredential": {
+			"id": "admin",
+			"password": "adminpw"
+		},
+		"adminCredential": {
+			"id": "exploreradmin",
+			"password": "exploreradminpw",
+			"affiliation": "org2.department1"
+		},
 		"organization": "org2",
 		"enableAuthentication": false,
 		"connection": {

--- a/app/platform/fabric/e2e-test/specs/apitest_test.go
+++ b/app/platform/fabric/e2e-test/specs/apitest_test.go
@@ -132,12 +132,12 @@ var _ = Describe("REST API Test Suite - Single profile", func() {
 
 		It("login to org1-network", func() {
 
-			resp := restPost("/auth/login", map[string]interface{}{"user": "admin", "password": "adminpw", "network": "org1-network"}, &LoginResponse{})
+			resp := restPost("/auth/login", map[string]interface{}{"user": "exploreradmin", "password": "exploreradminpw", "network": "org1-network"}, &LoginResponse{})
 			result := resp.Result().(*LoginResponse)
 			token = result.Token
 
 			Expect(result.User.Message).Should(Equal("logged in"))
-			Expect(result.User.Name).Should(Equal("admin"))
+			Expect(result.User.Name).Should(Equal("exploreradmin"))
 		})
 
 		It("get channels", func() {
@@ -374,24 +374,24 @@ var _ = Describe("REST API Test Suite - Multiple profile", func() {
 
 		Context("/auth/login", func() {
 			It("login to org1-network", func() {
-				resp := restPost("/auth/login", map[string]interface{}{"user": "admin", "password": "adminpw", "network": "org1-network"}, &LoginResponse{})
+				resp := restPost("/auth/login", map[string]interface{}{"user": "exploreradmin", "password": "exploreradminpw", "network": "org1-network"}, &LoginResponse{})
 				result := resp.Result().(*LoginResponse)
 				Expect(result.User.Message).Should(Equal("logged in"))
-				Expect(result.User.Name).Should(Equal("admin"))
+				Expect(result.User.Name).Should(Equal("exploreradmin"))
 			})
 
 			It("login to org2-network", func() {
-				resp := restPost("/auth/login", map[string]interface{}{"user": "admin", "password": "adminpw", "network": "org2-network"}, &LoginResponse{})
+				resp := restPost("/auth/login", map[string]interface{}{"user": "exploreradmin", "password": "exploreradminpw", "network": "org2-network"}, &LoginResponse{})
 				result := resp.Result().(*LoginResponse)
 				Expect(result.User.Message).Should(Equal("logged in"))
-				Expect(result.User.Name).Should(Equal("admin"))
+				Expect(result.User.Name).Should(Equal("exploreradmin"))
 			})
 		})
 
 		Context("/api/channels", func() {
 			It("get channels for Org1", func() {
 				// For org1
-				resp := restPost("/auth/login", map[string]interface{}{"user": "admin", "password": "adminpw", "network": "org1-network"}, &LoginResponse{})
+				resp := restPost("/auth/login", map[string]interface{}{"user": "exploreradmin", "password": "exploreradminpw", "network": "org1-network"}, &LoginResponse{})
 				resultLogin := resp.Result().(*LoginResponse)
 				token := resultLogin.Token
 				Expect(resultLogin.User.Message).Should(Equal("logged in"))
@@ -404,7 +404,7 @@ var _ = Describe("REST API Test Suite - Multiple profile", func() {
 
 			It("get channels for Org2", func() {
 				// For org2
-				resp := restPost("/auth/login", map[string]interface{}{"user": "admin", "password": "adminpw", "network": "org2-network"}, &LoginResponse{})
+				resp := restPost("/auth/login", map[string]interface{}{"user": "exploreradmin", "password": "exploreradminpw", "network": "org2-network"}, &LoginResponse{})
 				resultLogin := resp.Result().(*LoginResponse)
 				token := resultLogin.Token
 				Expect(resultLogin.User.Message).Should(Equal("logged in"))
@@ -420,7 +420,7 @@ var _ = Describe("REST API Test Suite - Multiple profile", func() {
 
 			It("get channels info for org1", func() {
 
-				resp1 := restPost("/auth/login", map[string]interface{}{"user": "admin", "password": "adminpw", "network": "org1-network"}, &LoginResponse{})
+				resp1 := restPost("/auth/login", map[string]interface{}{"user": "exploreradmin", "password": "exploreradminpw", "network": "org1-network"}, &LoginResponse{})
 				result1 := resp1.Result().(*LoginResponse)
 				token := result1.Token
 				Expect(result1.User.Message).Should(Equal("logged in"))
@@ -484,7 +484,7 @@ var _ = Describe("REST API Test Suite - Multiple profile", func() {
 
 			It("get channels info for org2", func() {
 
-				resp1 := restPost("/auth/login", map[string]interface{}{"user": "admin", "password": "adminpw", "network": "org2-network"}, &LoginResponse{})
+				resp1 := restPost("/auth/login", map[string]interface{}{"user": "exploreradmin", "password": "exploreradminpw", "network": "org2-network"}, &LoginResponse{})
 				result1 := resp1.Result().(*LoginResponse)
 				token := result1.Token
 				Expect(result1.User.Message).Should(Equal("logged in"))
@@ -552,7 +552,7 @@ var _ = Describe("REST API Test Suite - Multiple profile", func() {
 
 			It("get block info for org1", func() {
 
-				resp1 := restPost("/auth/login", map[string]interface{}{"user": "admin", "password": "adminpw", "network": "org1-network"}, &LoginResponse{})
+				resp1 := restPost("/auth/login", map[string]interface{}{"user": "exploreradmin", "password": "exploreradminpw", "network": "org1-network"}, &LoginResponse{})
 				result1 := resp1.Result().(*LoginResponse)
 				token := result1.Token
 				Expect(result1.User.Message).Should(Equal("logged in"))
@@ -583,7 +583,7 @@ var _ = Describe("REST API Test Suite - Multiple profile", func() {
 
 			It("get block info for org2", func() {
 
-				resp1 := restPost("/auth/login", map[string]interface{}{"user": "admin", "password": "adminpw", "network": "org2-network"}, &LoginResponse{})
+				resp1 := restPost("/auth/login", map[string]interface{}{"user": "exploreradmin", "password": "exploreradminpw", "network": "org2-network"}, &LoginResponse{})
 				result1 := resp1.Result().(*LoginResponse)
 				token := result1.Token
 				Expect(result1.User.Message).Should(Equal("logged in"))

--- a/client/e2e-test/configs/connection-profile/org1-network-for-guitest.json
+++ b/client/e2e-test/configs/connection-profile/org1-network-for-guitest.json
@@ -4,8 +4,11 @@
 	"license": "Apache-2.0",
 	"client": {
 		"tlsEnable": true,
-		"adminUser": "admin",
-		"adminPassword": "adminpw",
+		"adminCredential": {
+			"id": "admin",
+			"password": "adminpw",
+			"affiliation": "org1.department1"
+		},
 		"enableAuthentication": true,
 		"organization": "org1",
 		"connection": {


### PR DESCRIPTION
When specifying certificateAuthorities in connection profile,
generate certificates for admin user to access fabric network
using Fabric CA.

Signed-off-by: Atsushi Neki <atsushin@fast.au.fujitsu.com>

https://jira.hyperledger.org/browse/BE-773