### PR TITLE
BE-768 Add mTLS ID to gateway connect option

### DIFF
--- a/app/platform/fabric/e2e-test/configs/connection-profile/org1-network.json
+++ b/app/platform/fabric/e2e-test/configs/connection-profile/org1-network.json
@@ -4,6 +4,7 @@
 	"license": "Apache-2.0",
 	"client": {
 		"tlsEnable": true,
+		"clientTlsIdentity": "admin",
 		"caCredential": {
 			"id": "admin",
 			"password": "adminpw"

--- a/app/platform/fabric/gateway/FabricGateway.js
+++ b/app/platform/fabric/gateway/FabricGateway.js
@@ -120,6 +120,19 @@ class FabricGateway {
 				}
 			};
 
+			if ('clientTlsIdentity' in this.config.client) {
+				logger.info('client TLS enabled');
+				const mTlsIdLabel = this.config.client.clientTlsIdentity;
+				const mTlsId = await this.wallet.get(mTlsIdLabel);
+				if (mTlsId !== undefined) {
+					connectionOptions.clientTlsIdentity = mTlsIdLabel;
+				} else {
+					throw new ExplorerError(
+						`Not found Identity ${mTlsIdLabel} in your wallet`
+					);
+				}
+			}
+
 			// Connect to gateway
 			await this.gateway.connect(this.config, connectionOptions);
 			// this.client = this.gateway.getClient();


### PR DESCRIPTION
When configuring clientTlsIdentity in the connection profile, the ID is added to the connect option.

Signed-off-by: Atsushi Neki <atsushin@fast.au.fujitsu.com>

https://jira.hyperledger.org/browse/BE-768