### PR TITLE
Use FabricGateway's "asLocalhost" when running discovery service

### DIFF
--- a/app/platform/fabric/gateway/FabricGateway.js
+++ b/app/platform/fabric/gateway/FabricGateway.js
@@ -395,7 +395,7 @@ class FabricGateway {
 			ds.build(idx);
 			ds.sign(idx);
 			await ds.send({
-				asLocalhost: true,
+				asLocalhost: this.asLocalhost,
 				refreshAge: 15000,
 				targets: targets
 			});


### PR DESCRIPTION
The documented variable `DISCOVERY_AS_LOCALHOST` seems to ignored when running discovery service.

The `asLocalhost` option is hardcoded to `true`.

This PR makes the discovery service use the value configured during `initialize()`