### PR TITLE
BE-779 Reduce container image size

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,13 @@
 
 #SPDX-License-Identifier: Apache-2.0
-node_modules
-client/node_modules
-app/platform/fabric/e2e-test
+**/node_modules/
+client/build/
 wallet/
+logs/
+**/e2e-test/
+**/test/
+*.md
+docs/
+examples/
+.dockerignore
+.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,13 +3,47 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-FROM node:10.19-alpine3.9
+FROM node:10.19-alpine3.9 AS BUILD_IMAGE
 
 # default values pf environment variables
 # that are used inside container
 
 ENV DEFAULT_WORKDIR /opt
 ENV EXPLORER_APP_PATH $DEFAULT_WORKDIR/explorer
+
+# set default working dir inside container
+WORKDIR $EXPLORER_APP_PATH
+
+COPY . .
+
+# install required dependencies by NPM packages:
+# current dependencies are: python, make, g++
+RUN apk add --no-cache --virtual npm-deps python make g++ curl bash && \
+    python -m ensurepip && \
+    rm -r /usr/lib/python*/ensurepip && \
+    pip install --upgrade pip setuptools && \
+    rm -r /root/.cache
+
+# install node-prune (https://github.com/tj/node-prune)
+RUN curl -sfL https://install.goreleaser.com/github.com/tj/node-prune.sh | bash -s -- -b /usr/local/bin
+
+# install NPM dependencies
+RUN npm install && npm prune --production
+
+# build explorer app
+RUN cd client && npm install && npm prune --production && yarn build
+
+# remove installed packages to free space
+RUN apk del npm-deps
+RUN /usr/local/bin/node-prune
+
+RUN rm -rf node_modules/rxjs/src/
+RUN rm -rf node_modules/rxjs/bundles/
+RUN rm -rf node_modules/rxjs/_esm5/
+RUN rm -rf node_modules/rxjs/_esm2015/
+RUN rm -rf node_modules/grpc/deps/grpc/third_party/
+
+FROM node:10.19-alpine3.9
 
 # database configuration
 ENV DATABASE_HOST 127.0.0.1
@@ -18,31 +52,14 @@ ENV DATABASE_NAME fabricexplorer
 ENV DATABASE_USERNAME hppoc
 ENV DATABASE_PASSWD password
 
-ENV STARTUP_SCRIPT /opt
+ENV DEFAULT_WORKDIR /opt
+ENV EXPLORER_APP_PATH $DEFAULT_WORKDIR/explorer
 
-# set default working dir inside container
-WORKDIR $DEFAULT_WORKDIR
+WORKDIR $EXPLORER_APP_PATH
 
-# copy external data to container
-COPY . $EXPLORER_APP_PATH
-
-# install required dependencies by NPM packages:
-# current dependencies are: python, make, g++
-
-RUN apk add --no-cache --virtual npm-deps python make g++ && \
-    python -m ensurepip && \
-    rm -r /usr/lib/python*/ensurepip && \
-    pip install --upgrade pip setuptools && \
-	rm -r /root/.cache
-
-# install NPM dependencies
-RUN cd $EXPLORER_APP_PATH && npm install && npm build
-
-# build explorer app
-RUN cd $EXPLORER_APP_PATH && cd client && npm install && yarn build
-
-# remove installed packages to free space
-RUN apk del npm-deps
+COPY . .
+COPY --from=BUILD_IMAGE $EXPLORER_APP_PATH/client/build ./client/build/
+COPY --from=BUILD_IMAGE $EXPLORER_APP_PATH/node_modules ./node_modules/
 
 # expose default ports
 EXPOSE 8080


### PR DESCRIPTION
With the following changes to Dockerfile, reduce container image size from 942MB (compressed size on docker hub : 425MB) to less than 200MB.
 * Use Multi-Stage Docker Builds
 To avoid including unnecessary dependencies in the image
 * Add some entries to .dockerignore
 * Install only packages for production
 * Prune unnecessary files by using node-prune tool
 * Delete some large files manually

```
REPOSITORY             TAG                 IMAGE ID            CREATED              SIZE
hyperledger/explorer   latest              f1de39318a39        About a minute ago   166MB
hyperledger/explorer   1.1.1               35cf1f510efc        20 hours ago         942MB
```

Signed-off-by: Atsushi Neki <atsushin@fast.au.fujitsu.com>

https://jira.hyperledger.org/browse/BE-779