### PR TITLE
BE-792 Allow only "admin" to manage user

### DIFF
--- a/app/middleware/auth-check.js
+++ b/app/middleware/auth-check.js
@@ -26,9 +26,9 @@ module.exports = (req, res, next) => {
 			return res.status(401).end();
 		}
 
-		const userId = decoded.user;
+		const requestUserId = decoded.user;
 
-		req.userId = userId;
+		req.requestUserId = requestUserId;
 		req.network = decoded.network;
 
 		// TODO: check if a user exists, otherwise error

--- a/app/platform/fabric/Platform.js
+++ b/app/platform/fabric/Platform.js
@@ -178,7 +178,8 @@ class Platform {
 				username: combinedUserName,
 				salt: salt,
 				password: hashedPassword,
-				networkName: networkName
+				networkName: networkName,
+				roles: 'admin'
 			};
 
 			return Model.User.create(newUser)

--- a/app/platform/fabric/rest/adminroutes.js
+++ b/app/platform/fabric/rest/adminroutes.js
@@ -29,6 +29,7 @@ const adminroutes = async function(router, platform) {
 		responder(async req => {
 			const reqUser = await new User(req.body).asJson();
 			reqUser.network = req.network;
+			reqUser.requestUserId = req.requestUserId;
 			return await proxy.register(reqUser);
 		})
 	);
@@ -61,6 +62,7 @@ const adminroutes = async function(router, platform) {
 		responder(async req => {
 			const reqUser = await new User(req.body).asJson();
 			reqUser.network = req.network;
+			reqUser.requestUserId = req.requestUserId;
 			return await proxy.unregister(reqUser);
 		})
 	);


### PR DESCRIPTION
"admin" means as follow
* User specified with client.adminCredential in each connection profile
* User registered with 'admin' role by using user register API

The "admin" user can manage (register/unregister/list user) only for users in
the organization the admin belongs.

At the moment, the GUI interface for registering user on Explorer will
be showing even if you login with non admin user, but actual operations
(e.g. registering a new user) should be refused.

Signed-off-by: Atsushi Neki <atsushin@fast.au.fujitsu.com>