### PR TITLE
BE-814 Fix inconsistency of network key

### DIFF
--- a/app/persistence/fabric/CRUDService.js
+++ b/app/persistence/fabric/CRUDService.js
@@ -236,6 +236,7 @@ class CRUDService {
 		);
 
 		if (isValidRow(c)) {
+			transaction.network_name = network_name;
 			await this.sql.saveRow('transactions', transaction);
 			await this.sql.updateBySql(
 				`update chaincodes set txcount =txcount+1 where channel_genesis_hash='${transaction.channel_genesis_hash}' and network_name = '${network_name}' and name='${transaction.chaincodename}'`

--- a/app/platform/fabric/FabricConfig.js
+++ b/app/platform/fabric/FabricConfig.js
@@ -32,8 +32,10 @@ class FabricConfig {
 	 * @memberof FabricConfig
 	 */
 
-	initialize(configPath) {
-		const configJson = fs.readFileSync(configPath, 'utf8');
+	initialize(network_id, network_config) {
+		this.network_id = network_id;
+		const profile_path = path.resolve(__dirname, network_config.profile);
+		const configJson = fs.readFileSync(profile_path, 'utf8');
 		this.config = JSON.parse(configJson);
 	}
 
@@ -175,8 +177,8 @@ class FabricConfig {
 	 * @returns
 	 * @memberof FabricConfig
 	 */
-	getNetworkName() {
-		return this.config.name;
+	getNetworkId() {
+		return this.network_id;
 	}
 
 	/**

--- a/app/platform/fabric/Proxy.js
+++ b/app/platform/fabric/Proxy.js
@@ -68,10 +68,10 @@ class Proxy {
 	 * @returns
 	 * @memberof Proxy
 	 */
-	async getCurrentChannel(network_name) {
-		logger.debug('getCurrentChannel: network_name', network_name);
+	async getCurrentChannel(network_id) {
+		logger.debug('getCurrentChannel: network_id', network_id);
 
-		const client = await this.platform.getClient(network_name);
+		const client = await this.platform.getClient(network_id);
 		const channel_name = Object.keys(client.fabricGateway.config.channels)[0];
 		const channel_genesis_hash = client.getChannelGenHash(channel_name);
 		let respose;
@@ -97,12 +97,12 @@ class Proxy {
 	 * @returns
 	 * @memberof Proxy
 	 */
-	async getPeersStatus(network_name, channel_genesis_hash) {
-		const client = await this.platform.getClient(network_name);
+	async getPeersStatus(network_id, channel_genesis_hash) {
+		const client = await this.platform.getClient(network_id);
 		const channel_name = client.getChannelNameByHash(channel_genesis_hash);
 		const nodes = await this.persistence
 			.getMetricService()
-			.getPeerList(network_name, channel_genesis_hash);
+			.getPeerList(network_id, channel_genesis_hash);
 		let discover_results;
 		if (client.status) {
 			try {
@@ -158,7 +158,7 @@ class Proxy {
 	 * @returns
 	 * @memberof Proxy
 	 */
-	async changeChannel(network_name, channel_genesis_hash) {
+	async changeChannel(network_id, channel_genesis_hash) {
 		return channel_genesis_hash;
 	}
 
@@ -168,11 +168,11 @@ class Proxy {
 	 * @returns
 	 * @memberof Proxy
 	 */
-	async getChannelsInfo(network_name) {
-		const client = this.platform.getClient(network_name);
+	async getChannelsInfo(network_id) {
+		const client = this.platform.getClient(network_id);
 		const channels = await this.persistence
 			.getCrudService()
-			.getChannelsInfo(network_name);
+			.getChannelsInfo(network_id);
 		const currentchannels = [];
 		for (const channel of channels) {
 			const channel_genesis_hash = client.getChannelGenHash(channel.channelname);
@@ -194,13 +194,13 @@ class Proxy {
 	 * @returns
 	 * @memberof Proxy
 	 */
-	async getTxByOrgs(network_name, channel_genesis_hash) {
+	async getTxByOrgs(network_id, channel_genesis_hash) {
 		const rows = await this.persistence
 			.getMetricService()
-			.getTxByOrgs(network_name, channel_genesis_hash);
+			.getTxByOrgs(network_id, channel_genesis_hash);
 		const organizations = await this.persistence
 			.getMetricService()
-			.getOrgsData(network_name, channel_genesis_hash);
+			.getOrgsData(network_id, channel_genesis_hash);
 
 		for (const organization of rows) {
 			const index = organizations.indexOf(organization.creator_msp_id);
@@ -225,8 +225,8 @@ class Proxy {
 	 * @returns
 	 * @memberof Proxy
 	 */
-	async getBlockByNumber(network_name, channel_genesis_hash, number) {
-		const client = this.platform.getClient(network_name);
+	async getBlockByNumber(network_id, channel_genesis_hash, number) {
+		const client = this.platform.getClient(network_id);
 		const channelName = client.getChannelNameByHash(channel_genesis_hash);
 		let block;
 
@@ -260,12 +260,12 @@ class Proxy {
 	 * @returns
 	 * @memberof Proxy
 	 */
-	async getChannels(network_name) {
-		const client = this.platform.getClient(network_name);
+	async getChannels(network_id) {
+		const client = this.platform.getClient(network_id);
 		const client_channels = client.getChannelNames();
 		const channels = await this.persistence
 			.getCrudService()
-			.getChannelsInfo(network_name);
+			.getChannelsInfo(network_id);
 		const respose = [];
 
 		for (let i = 0; i < channels.length; i++) {
@@ -328,8 +328,8 @@ class Proxy {
 		logger.debug('Message from child %j', msg);
 		if (fabric_const.NOTITY_TYPE_NEWCHANNEL === msg.notify_type) {
 			// Initialize new channel instance in parent
-			if (msg.network_name && msg.client_name) {
-				const client = this.platform.getClient(msg.network_name);
+			if (msg.network_id) {
+				const client = this.platform.getClient(msg.network_id);
 				if (msg.channel_name) {
 					client.initializeNewChannel(msg.channel_name);
 				} else {
@@ -347,8 +347,8 @@ class Proxy {
 			fabric_const.NOTITY_TYPE_CHAINCODE === msg.notify_type
 		) {
 			// Update channel details in parent
-			if (msg.network_name && msg.client_name) {
-				const client = this.platform.getClient(msg.network_name);
+			if (msg.network_id) {
+				const client = this.platform.getClient(msg.network_id);
 				if (msg.channel_name) {
 					client.initializeChannelFromDiscover(msg.channel_name);
 				} else {

--- a/app/platform/fabric/config.json
+++ b/app/platform/fabric/config.json
@@ -1,7 +1,7 @@
 {
 	"network-configs": {
 		"first-network": {
-			"name": "first-network",
+			"name": "My first network",
 			"profile": "./connection-profile/first-network.json"
 		}
 	},

--- a/app/platform/fabric/connection-profile/first-network.json
+++ b/app/platform/fabric/connection-profile/first-network.json
@@ -1,5 +1,5 @@
 {
-	"name": "first-network",
+	"name": "first network (ignored)",
 	"version": "1.0.0",
 	"license": "Apache-2.0",
 	"client": {
@@ -44,18 +44,18 @@
 		"Org1MSP": {
 			"mspid": "Org1MSP",
 			"adminPrivateKey": {
-				"path": "/fabric-path/fabric-samples/test-network/organizations/peerOrganizations/org1.example.com/users/Admin@org1.example.com/msp/keystore/priv_sk"
+				"path": "/home/atsushi/dev/hyperledger/fabric-samples/test-network/organizations/peerOrganizations/org1.example.com/users/Admin@org1.example.com/msp/keystore/priv_sk"
 			},
 			"peers": ["peer0.org1.example.com"],
 			"signedCert": {
-				"path": "/fabric-path/fabric-samples/test-network/organizations/peerOrganizations/org1.example.com/users/Admin@org1.example.com/msp/signcerts/Admin@org1.example.com-cert.pem"
+				"path": "/home/atsushi/dev/hyperledger/fabric-samples/test-network/organizations/peerOrganizations/org1.example.com/users/Admin@org1.example.com/msp/signcerts/Admin@org1.example.com-cert.pem"
 			}
 		}
 	},
 	"peers": {
 		"peer0.org1.example.com": {
 			"tlsCACerts": {
-				"path": "/fabric-path/fabric-samples/test-network/organizations/peerOrganizations/org1.example.com/peers/peer0.org1.example.com/tls/ca.crt"
+				"path": "/home/atsushi/dev/hyperledger/fabric-samples/test-network/organizations/peerOrganizations/org1.example.com/peers/peer0.org1.example.com/tls/ca.crt"
 			},
 			"url": "grpcs://localhost:7051",
 			"grpcOptions": {
@@ -70,7 +70,7 @@
 				"verify": false
 			},
 			"tlsCACerts": {
-				"path": "/fabric-path/fabric-samples/first-network/crypto-config/peerOrganizations/org1/ca/ca.org1-cert.pem"
+				"path": "/home/atsushi/dev/hyperledger/fabric-samples/first-network/crypto-config/peerOrganizations/org1/ca/ca.org1-cert.pem"
 			},
 			"caName": "ca0-org1"
 		}

--- a/app/platform/fabric/e2e-test/configs/config_multi.json
+++ b/app/platform/fabric/e2e-test/configs/config_multi.json
@@ -1,11 +1,11 @@
 {
 	"network-configs": {
 		"org1-network": {
-			"name": "org1-network",
+			"name": "org1 network",
 			"profile": "./e2e-test/configs/connection-profile/org1-network.json"
 		},
 		"org2-network": {
-			"name": "org2-network",
+			"name": "org2 network",
 			"profile": "./e2e-test/configs/connection-profile/org2-network.json"
 		}
 	},

--- a/app/platform/fabric/e2e-test/specs/apitest_def_test.go
+++ b/app/platform/fabric/e2e-test/specs/apitest_def_test.go
@@ -125,6 +125,7 @@ type PeersStatusResp struct {
 
 type Network struct {
 	Name     string      `json:"name"`
+	Id       string      `json:"id"`
 	Instance interface{} `json:"instance"`
 }
 

--- a/app/platform/fabric/e2e-test/specs/apitest_test.go
+++ b/app/platform/fabric/e2e-test/specs/apitest_test.go
@@ -42,12 +42,16 @@ func basicCheck(loginId string) {
 		resp := restGet("/auth/networklist", &NetworklistInfo{})
 
 		result := resp.Result().(*NetworklistInfo)
-		list := []string{}
+		nameList := []string{}
+		idList := []string{}
 		for _, val := range result.NetworkList {
-			list = append(list, val.Name)
+			nameList = append(nameList, val.Name)
+			idList = append(idList, val.Id)
 		}
-		Expect(list).Should(HaveLen(1))
-		Expect(list).Should(ContainElements([]string{"org1-network"}))
+		Expect(nameList).Should(HaveLen(1))
+		Expect(nameList).Should(ContainElements([]string{"org1-network"}))
+		Expect(idList).Should(HaveLen(1))
+		Expect(idList).Should(ContainElements([]string{"org1-network"}))
 	})
 
 	It("login to org1-network", func() {
@@ -466,12 +470,16 @@ var _ = Describe("REST API Test Suite - Multiple profile", func() {
 			It("get network list", func() {
 				resp := restGet("/auth/networklist", &NetworklistInfo{})
 				result := resp.Result().(*NetworklistInfo)
-				list := []string{}
+				nameList := []string{}
+				idList := []string{}
 				for _, val := range result.NetworkList {
-					list = append(list, val.Name)
+					nameList = append(nameList, val.Name)
+					idList = append(idList, val.Id)
 				}
-				Expect(list).Should(HaveLen(2))
-				Expect(list).Should(ContainElements([]string{"org1-network", "org2-network"}))
+				Expect(nameList).Should(HaveLen(2))
+				Expect(nameList).Should(ContainElements([]string{"org1 network", "org2 network"}))
+				Expect(idList).Should(HaveLen(2))
+				Expect(idList).Should(ContainElements([]string{"org1-network", "org2-network"}))
 
 			})
 		})

--- a/app/platform/fabric/gateway/FabricGateway.js
+++ b/app/platform/fabric/gateway/FabricGateway.js
@@ -21,20 +21,22 @@ const helper = require('../../../common/helper');
 const logger = helper.getLogger('FabricGateway');
 const explorer_mess = require('../../../common/ExplorerMessage').explorer;
 const ExplorerError = require('../../../common/ExplorerError');
-const FabricConfig = require('../FabricConfig');
 
 class FabricGateway {
-	constructor(networkConfig) {
-		this.networkConfig = networkConfig;
-		this.config = null;
+	/**
+	 * Creates an instance of FabricGateway.
+	 * @param {FabricConfig} config
+	 * @memberof FabricGateway
+	 */
+	constructor(fabricConfig) {
+		this.fabricConfig = fabricConfig;
+		this.config = this.fabricConfig.getConfig();
 		this.gateway = null;
 		this.wallet = null;
 		this.tlsEnable = false;
 		this.defaultChannelName = null;
 		this.gateway = new Gateway();
-		this.fabricConfig = new FabricConfig();
 		this.fabricCaEnabled = false;
-		this.networkName = null;
 		this.client = null;
 		this.FSWALLET = null;
 		this.enableAuthentication = false;
@@ -42,15 +44,10 @@ class FabricGateway {
 	}
 
 	async initialize() {
-		const configPath = path.resolve(__dirname, this.networkConfig);
-		this.fabricConfig = new FabricConfig();
-		this.fabricConfig.initialize(configPath);
-		this.config = this.fabricConfig.getConfig();
 		this.fabricCaEnabled = this.fabricConfig.isFabricCaEnabled();
 		this.tlsEnable = this.fabricConfig.getTls();
 		this.enableAuthentication = this.fabricConfig.getEnableAuthentication();
-		this.networkName = this.fabricConfig.getNetworkName();
-		this.FSWALLET = 'wallet/' + this.networkName;
+		this.FSWALLET = 'wallet/' + this.fabricConfig.getNetworkId();
 
 		const explorerAdminId = this.fabricConfig.getAdminUser();
 		if (!explorerAdminId) {

--- a/app/platform/fabric/service/NetworkService.js
+++ b/app/platform/fabric/service/NetworkService.js
@@ -32,10 +32,11 @@ class NetworkService {
 		const networklist = [];
 		const networks = this.platform.getNetworks();
 		logger.debug('Network list ', networks);
-		for (const [networkName, clientObj] of networks.entries()) {
-			logger.debug('Network list ', networkName);
+		for (const [network_id, clientObj] of networks.entries()) {
+			logger.debug('Network list ', clientObj.name);
 			networklist.push({
-				name: networkName,
+				id: network_id,
+				name: clientObj.name,
 				authEnabled: clientObj.instance.fabricGateway.getEnableAuthentication()
 			});
 		}

--- a/app/platform/fabric/utils/FabricUtils.js
+++ b/app/platform/fabric/utils/FabricUtils.js
@@ -15,84 +15,20 @@ const helper = require('../../../common/helper');
 
 const logger = helper.getLogger('FabricUtils');
 
-async function createFabricClient(
-	client_configs,
-	network_name,
-	client_name,
-	persistence
-) {
+async function createFabricClient(config, persistence) {
 	// Create new FabricClient
-	const client = new FabricClient(network_name, client_name);
+	const client = new FabricClient(config);
 	// Initialize fabric client
 	logger.debug(
 		'************ Initializing fabric client for [%s]************',
-		client_name
+		config.getNetworkId()
 	);
 	try {
-		await client.initialize(client_configs, persistence);
+		await client.initialize(persistence);
 		return client;
 	} catch (err) {
 		throw new ExplorerError(explorer_error.ERROR_2014);
 	}
-}
-
-async function createDetachClient(
-	client_configs,
-	network_name,
-	client_name,
-	persistence
-) {
-	// Clone global.hfc.config configuration
-	const client_config = cloneConfig(client_configs, client_name);
-
-	const client = new FabricClient(network_name, client_name);
-	await client.initializeDetachClient(client_config, persistence);
-	return client;
-}
-
-function cloneConfig(client_configs, client_name) {
-	const global_hfc_config = JSON.parse(JSON.stringify(global.hfc.config));
-
-	let client_config = global_hfc_config;
-	client_config.client = client_configs.clients[client_name];
-	client_config.version = client_configs.version;
-	client_config.channels = client_configs.channels;
-	client_config.organizations = client_configs.organizations;
-	client_config.peers = client_configs.peers;
-	client_config.orderers = client_configs.orderers;
-	client_config.certificateAuthorities = client_configs.certificateAuthorities;
-
-	// Modify url with respect to TLS enable
-	client_config = processTLS_URL(client_config);
-	return client_config;
-}
-
-/**
- *
- *
- * @param {*} client_config
- * @returns
- */
-function processTLS_URL(client_config) {
-	for (const peer_name in client_config.peers) {
-		const url = client_config.peers[peer_name].url;
-		client_config.peers[peer_name].url = client_config.client.tlsEnable
-			? `grpcs${url.substring(url.indexOf('://'))}`
-			: `grpc${url.substring(url.indexOf('://'))}`;
-		if (client_config.peers[peer_name].eventUrl) {
-			const eventUrl = client_config.peers[peer_name].eventUrl;
-			client_config.peers[peer_name].eventUrl = client_config.client.tlsEnable
-				? `grpcs${eventUrl.substring(eventUrl.indexOf('://'))}`
-				: `grpc${eventUrl.substring(eventUrl.indexOf('://'))}`;
-		}
-	}
-	for (const ord_name in client_config.orderers) {
-		const url = client_config.orderers[ord_name].url;
-		client_config.orderers[ord_name].url = client_config.client.tlsEnable
-			? `grpcs${url.substring(url.indexOf('://'))}`
-			: `grpc${url.substring(url.indexOf('://'))}`;
-	}
-	return client_config;
 }
 
 /**
@@ -197,4 +133,3 @@ exports.createFabricClient = createFabricClient;
 exports.getBlockTimeStamp = getBlockTimeStamp;
 exports.generateDir = generateDir;
 exports.getPEMfromConfig = getPEMfromConfig;
-exports.createDetachClient = createDetachClient;

--- a/client/src/components/Login/Login.js
+++ b/client/src/components/Login/Login.js
@@ -91,7 +91,8 @@ export class Login extends Component {
 			},
 			network: {
 				error: null,
-				value: ''
+				value: '',
+				id: ''
 			},
 			autoLoginAttempted: false,
 			error: '',
@@ -107,7 +108,8 @@ export class Login extends Component {
 			networks,
 			network: {
 				error: null,
-				value: networks[0].name || ''
+				value: networks[0].name || '',
+				id: networks[0].id
 			},
 			authEnabled: networks[0].authEnabled
 		}));
@@ -123,20 +125,23 @@ export class Login extends Component {
 		};
 		if (name === 'network') {
 			const { networks } = this.state;
-			newState.authEnabled = (networks.find(n => n.name === value) || {}).authEnabled;
+			newState.authEnabled = (
+				networks.find(n => n.name === value) || {}
+			).authEnabled;
+			newState.network.id = (networks.find(n => n.name === value) || {}).id;
 		}
 
 		this.setState(newState);
 	};
 
-	async performLogin({ user, password, network}) {
+	async performLogin({ user, password, network }) {
 		const { login } = this.props;
 		const { authEnabled } = this.state;
 
 		const info = await login(
 			{
 				user: authEnabled ? user : 'dummy-user',
-				password: authEnabled ? password : 'dummy-password',
+				password: authEnabled ? password : 'dummy-password'
 			},
 			network
 		);
@@ -157,25 +162,40 @@ export class Login extends Component {
 		await this.performLogin({
 			user: user.value,
 			password: password.value,
-			network: network.value
+			network: network.id
 		});
 	};
 
 	async componentDidUpdate() {
 		const { networks, autoLoginAttempted } = this.state;
 
-		// If we have only one network and it doesn't have auth enabled, perform a login
-		// autoLoginAttempted is a safety to prevent multiple tries
-		if (networks.length === 1 && !networks[0].authEnabled && !autoLoginAttempted) {
+		/*
+		 * If we have only one network and it doesn't have auth enabled, perform a login
+		 * autoLoginAttempted is a safety to prevent multiple tries
+		 */
+		if (
+			networks.length === 1 &&
+			!networks[0].authEnabled &&
+			!autoLoginAttempted
+		) {
+			// eslint-disable-next-line react/no-did-update-set-state
 			this.setState(() => ({
 				autoLoginAttempted: true
 			}));
-			await this.performLogin({ network: networks[0].name })
+			await this.performLogin({ network: networks[0].name });
 		}
 	}
 
 	render() {
-		const { info, user, password, network, networks, authEnabled, isLoading } = this.state;
+		const {
+			info,
+			user,
+			password,
+			network,
+			networks,
+			authEnabled,
+			isLoading
+		} = this.state;
 		const { classes, error } = this.props;
 
 		return (
@@ -249,8 +269,8 @@ export class Login extends Component {
 									</FormHelperText>
 								)}
 							</FormControl>
-							)}
-							{authEnabled && (
+						)}
+						{authEnabled && (
 							<FormControl margin="normal" required fullWidth>
 								<TextField
 									required
@@ -297,7 +317,7 @@ export class Login extends Component {
 							color="primary"
 							className={classes.submit}
 						>
-							{authEnabled ? "Sign in" : "Connect"}
+							{authEnabled ? 'Sign in' : 'Connect'}
 						</Button>
 					</form>
 				</Paper>


### PR DESCRIPTION
Fixed to use only network ID for managing state internally (network Name is used only for showing network name on Login view)

```json
app/platform/fabric/config.json
{
	"network-configs": {
		"first-network": {  <===[Network-ID]
			"name": "My first network",   <===[Network-Name]
			"profile": "./connection-profile/first-network.json"
		}
	},
	"license": "Apache-2.0"
}
```

The name in a connection profile is not used any purpose.

```json
app/platform/fabric/connection-profile/first-network.json
{
	"name": "first network (ignored)",   <===[NotUsed]
	"version": "1.0.0",
	"license": "Apache-2.0",
	"client": {
		"tlsEnable": true,
		
```

Signed-off-by: Atsushi Neki <atsushin@fast.au.fujitsu.com>