### PR TITLE
BE-858 Upgrade base image of Explorer container image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-FROM node:10.19-alpine3.9 AS BUILD_IMAGE
+FROM node:14.16.0-alpine3.13 AS BUILD_IMAGE
 
 # default values pf environment variables
 # that are used inside container


### PR DESCRIPTION
The current node version (10.19-alpine3.9) has some vulnerabilities. Please refer the following JIRA for detail.

https://jira.hyperledger.org/browse/BE-858

Signed-off-by: Atsushi Neki <nekiaiken@gmail.com>