### PR TITLE
add typescript compilation on main.sh install

### DIFF
--- a/main.sh
+++ b/main.sh
@@ -18,7 +18,7 @@ function print_help() {
 
 function do_install() {
 	VERBOSE=${VERBOSE:+-ddd}
-	npm install $VERBOSE
+	(npm install $VERBOSE && npm run build)
 	(cd client && npm install $VERBOSE && npm run build)
 }
 


### PR DESCRIPTION
As mentioned on RocketChat, running tsc is mandatory now before one can start the backend with start.sh

I added the tsc step with npm run build in main.sh

Signed-off-by: sigma67 <benedikt.putz@wiwi.uni-regensburg.de>