### PR TITLE
BE-855 Stop unnecessary sync process triggered by FabricEvent

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -439,7 +439,8 @@
 				"@typescript-eslint/no-explicit-any": "off",
 				"@typescript-eslint/explicit-module-boundary-types": "off",
 				"no-console": ["error"],
-				"import/extensions": ["off"]
+				"import/extensions": ["off"],
+				"wrap-iife": ["error", "inside"]
 			}
 		}
 	]

--- a/app/platform/fabric/sync/FabricEvent.ts
+++ b/app/platform/fabric/sync/FabricEvent.ts
@@ -2,7 +2,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {helper} from '../../../common/helper';
+import { helper } from '../../../common/helper';
 
 const logger = helper.getLogger('FabricEvent');
 
@@ -12,10 +12,9 @@ const logger = helper.getLogger('FabricEvent');
  * @class FabricEvent
  */
 export class FabricEvent {
-
-	client : any;
-	fabricServices : any;
-	static channelEventHubs : any;
+	client: any;
+	fabricServices: any;
+	static channelEventHubs: any;
 
 	/**
 	 * Creates an instance of FabricEvent.
@@ -47,7 +46,7 @@ export class FabricEvent {
 				continue;
 			}
 
-			this.createChannelEventHub(channel_name);
+			await this.createChannelEventHub(channel_name);
 		}
 	}
 
@@ -71,7 +70,7 @@ export class FabricEvent {
 					}
 				},
 				{
-					startBlock: 1,
+					// Keep startBlock undefined because expecting to start listening from the current block.
 					type: 'full'
 				}
 			);

--- a/app/platform/fabric/sync/SyncPlatform.ts
+++ b/app/platform/fabric/sync/SyncPlatform.ts
@@ -100,15 +100,14 @@ export class SyncPlatform {
 		}
 
 		// Updating the client network and other details to DB
-		const res = await this.syncService.synchNetworkConfigToDB(this.client);
-		if (!res) {
-			return;
-		}
-
-		setInterval(() => {
+		(async function updateNetworkConfig(sync) {
 			logger.info('Updating the client network and other details to DB');
-			this.syncService.synchNetworkConfigToDB(this.client);
-		}, 30000);
+			const res = await sync.syncService.synchNetworkConfigToDB(sync.client);
+			if (!res) {
+				logger.error('Failed to update network config to DB');
+			}
+			setTimeout(updateNetworkConfig, 30000, sync);
+		})(this);
 
 		// Start event
 		this.eventHub = new FabricEvent(this.client, this.syncService);
@@ -118,9 +117,11 @@ export class SyncPlatform {
 		 * Setting interval for validating any missing block from the current client ledger
 		 * Set blocksSyncTime property in platform config.json in minutes
 		 */
-		setInterval(() => {
-			this.isChannelEventHubConnected();
-		}, this.blocksSyncTime);
+		(function validateMissingBlocks(sync) {
+			sync.isChannelEventHubConnected();
+			setTimeout(validateMissingBlocks, sync.blocksSyncTime, sync);
+		})(this);
+
 		logger.debug(
 			'******* Initialization end for child client process %s ******',
 			this.network_id
@@ -137,7 +138,7 @@ export class SyncPlatform {
 			// Validate channel event is connected
 			const status = this.eventHub.isChannelEventHubConnected(channel_name);
 			if (status) {
-				await this.syncService.synchBlocks(this.client, channel_name);
+				await this.syncService.syncBlocks(this.client, channel_name);
 			} else {
 				// Channel client is not connected then it will reconnect
 				this.eventHub.connectChannelEventHub(channel_name);

--- a/app/platform/fabric/sync/SyncPlatform.ts
+++ b/app/platform/fabric/sync/SyncPlatform.ts
@@ -100,7 +100,7 @@ export class SyncPlatform {
 		}
 
 		// Updating the client network and other details to DB
-		(async function updateNetworkConfig(sync) {
+		await (async function updateNetworkConfig(sync) {
 			logger.info('Updating the client network and other details to DB');
 			const res = await sync.syncService.synchNetworkConfigToDB(sync.client);
 			if (!res) {

--- a/app/platform/fabric/sync/SyncService.ts
+++ b/app/platform/fabric/sync/SyncService.ts
@@ -354,12 +354,13 @@ export class SyncServices {
 			.saveChaincodPeerRef(network_id, chaincode_peer_row);
 	}
 
-	async synchBlocks(client, channel_name) {
+	async syncBlocks(client, channel_name) {
 		const network_id = client.getNetworkId();
 
 		const synch_key = `${network_id}_${channel_name}`;
+		logger.info(`syncBlocks: Start >> ${synch_key}`);
 		if (this.synchInProcess.includes(synch_key)) {
-			logger.info(`Block synch in process for >> ${network_id}_${channel_name}`);
+			logger.info(`syncBlocks: Block sync in process for >> ${synch_key}`);
 			return;
 		}
 		this.synchInProcess.push(synch_key);
@@ -393,6 +394,7 @@ export class SyncServices {
 		}
 		const index = this.synchInProcess.indexOf(synch_key);
 		this.synchInProcess.splice(index, 1);
+		logger.info(`syncBlocks: Finish >> ${synch_key}`);
 	}
 
 	async updateDiscoveredChannel(client, channel_name, channel_genesis_hash) {

--- a/app/platform/fabric/sync/SyncService.ts
+++ b/app/platform/fabric/sync/SyncService.ts
@@ -107,6 +107,9 @@ export class SyncServices {
 			} else {
 				return false;
 			}
+
+			// Need that chaincode table is synced up to existing chaincode at this moment
+			await this.insertNewChannelChaincode(client, channel_genesis_hash, null);
 		}
 		return true;
 	}
@@ -305,7 +308,7 @@ export class SyncServices {
 			await this.persistence
 				.getCrudService()
 				.saveChaincode(network_id, chaincode_row);
-			if (discoveryResults && discoveryResults.peers_by_org) {
+			if (discoveryResults?.peers_by_org) {
 				for (const org_name in discoveryResults.peers_by_org) {
 					const org = discoveryResults.peers_by_org[org_name];
 					for (const peer of org.peers) {

--- a/app/test/SyncService.test.ts
+++ b/app/test/SyncService.test.ts
@@ -204,7 +204,7 @@ describe('processBlockEvent', () => {
 	});
 });
 
-describe('synchBlocks', () => {
+describe('syncBlocks', () => {
 	let sync: SyncServices;
 
 	before(() => {
@@ -219,7 +219,7 @@ describe('synchBlocks', () => {
 		const stubClient = setupClient();
 		const stubProcessBlockEvent = sinon.stub(sync, 'processBlockEvent');
 
-		await sync.synchBlocks(stubClient, VALID_CHANNEL_NAME);
+		await sync.syncBlocks(stubClient, VALID_CHANNEL_NAME);
 		expect(stubProcessBlockEvent.calledTwice).to.be.true;
 		stubProcessBlockEvent.restore();
 	});
@@ -230,7 +230,7 @@ describe('synchBlocks', () => {
 		stubProcessBlockEvent.onFirstCall().throws('Block already in processing');
 		stubError.reset();
 
-		await sync.synchBlocks(stubClient, VALID_CHANNEL_NAME);
+		await sync.syncBlocks(stubClient, VALID_CHANNEL_NAME);
 		expect(stubProcessBlockEvent.calledTwice).to.be.true;
 		expect(stubError.calledWith('Failed to process Block # 1')).to.be.true;
 		expect(stubError.calledWith('Failed to process Block # 2')).to.be.false;

--- a/client/e2e-test/startnetwork.js
+++ b/client/e2e-test/startnetwork.js
@@ -141,7 +141,7 @@ startNetwork = async () => {
 	}
 
 	// Wait for a while to get ready to start REST API server
-	await new Promise(r => setTimeout(r, 20000));
+	await new Promise(r => setTimeout(r, 40000));
 };
 
 startNetwork();


### PR DESCRIPTION
Signed-off-by: Atsushi Neki <nekiaiken@gmail.com>

This change includes:
* Fixed unintended asynchronous function calls
* Change block synchronization by FabricEvent to start from the current block (Unintentionally multiple block sync processes had been triggered at bootup)
* Introduced immediate invoked function exression (IIFE) into some initialization steps of SyncPlatform 
* Add a step for sync up of chaincode table to synchNetworkConfigToDB method (Some transactions included in block data hadn't been counted as transaction for each chaincode until chaincode table is updated by service discovery )
