### PR TITLE
Bugfix: disable enableAuthentication auth auto login using wrong network key issue

### DIFF
--- a/client/src/components/Login/Login.js
+++ b/client/src/components/Login/Login.js
@@ -181,7 +181,7 @@ export class Login extends Component {
 			this.setState(() => ({
 				autoLoginAttempted: true
 			}));
-			await this.performLogin({ network: networks[0].name });
+			await this.performLogin({ network: networks[0].value });
 		}
 	}
 

--- a/client/src/components/Login/Login.js
+++ b/client/src/components/Login/Login.js
@@ -181,7 +181,7 @@ export class Login extends Component {
 			this.setState(() => ({
 				autoLoginAttempted: true
 			}));
-			await this.performLogin({ network: networks[0].value });
+			await this.performLogin({ network: networks[0].id });
 		}
 	}
 


### PR DESCRIPTION
## This PR:
- resolves `enableAuthentication:false` setup using wrong network key preventing auto login issue.

## Screenshot:
![image](https://user-images.githubusercontent.com/10151054/122209322-fa253e00-ced6-11eb-87a6-1755f9b3e9b1.png)
