### PR TITLE
Bugfix: timeout error crashing explorer

### DIFF
--- a/app/platform/fabric/gateway/FabricGateway.ts
+++ b/app/platform/fabric/gateway/FabricGateway.ts
@@ -434,13 +434,26 @@ export class FabricGateway {
 			if (!this.waitingResp) {
 				this.waitingResp = true;
 				logger.info('Sending discovery request...');
-				await this.ds.send({
-					asLocalhost: this.asLocalhost,
-					requestTimeout: 5000,
-					refreshAge: 15000,
-					targets: this.dsTargets
-				});
-				logger.info('Succeeded to send discovery request');
+				await this.ds
+          .send({
+            asLocalhost: this.asLocalhost,
+            requestTimeout: 5000,
+            refreshAge: 15000,
+            targets: this.dsTargets,
+          })
+          .then(() => {
+            logger.info('Succeeded to send discovery request');
+          })
+          .catch(error => {
+            if (error) {
+              logger.warn(
+                'Failed to send discovery request for channel',
+                error,
+              );
+              this.waitingResp = false;
+              this.ds.close();
+            }
+          });
 			} else {
 				logger.info('Have already been sending a request');
 				return null;

--- a/app/platform/fabric/sync/SyncService.ts
+++ b/app/platform/fabric/sync/SyncService.ts
@@ -360,6 +360,15 @@ export class SyncServices {
 	async syncBlocks(client, channel_name) {
 		const network_id = client.getNetworkId();
 
+    // Get channel information from ledger
+    const channelInfo = await client.fabricGateway.queryChainInfo(channel_name);
+
+    if (!channelInfo) {
+      logger.info(
+        `syncBlocks: Failed to retrieve channelInfo >> ${channel_name}`,
+      );
+      return;
+    }
 		const synch_key = `${network_id}_${channel_name}`;
 		logger.info(`syncBlocks: Start >> ${synch_key}`);
 		if (this.synchInProcess.includes(synch_key)) {
@@ -368,8 +377,6 @@ export class SyncServices {
 		}
 		this.synchInProcess.push(synch_key);
 
-		// Get channel information from ledger
-		const channelInfo = await client.fabricGateway.queryChainInfo(channel_name);
 		const channel_genesis_hash = client.getChannelGenHash(channel_name);
 		const blockHeight = parseInt(channelInfo.height.low) - 1;
 		// Query missing blocks from DB

--- a/app/sync.ts
+++ b/app/sync.ts
@@ -58,7 +58,10 @@ process.on('unhandledRejection', (up : {message : string}) => {
 	} else {
 		logger.error(up);
 	}
-	shutDown();
+  // prevent timeout error from calling shutdown
+	if (!up.message.includes('REQUEST TIMEOUT')) {
+    shutDown();
+  }
 });
 process.on('uncaughtException', up => {
 	logger.error(


### PR DESCRIPTION
## This PR:
- resolves `discoveryError` not resetting `waitingResp` flag, causing a `Have already been sending a request` loop.
```
[WARN] FabricGateway - Failed to send discovery request for channel Error: DiscoveryService has failed to return results
    at DiscoveryService.send (.../blockchain-explorer/node_modules/fabric-common/lib/DiscoveryService.js:370:10)
    at processTicksAndRejections (internal/process/task_queues.js:97:5)
...
[INFO] FabricGateway - Have already been sending a request
[INFO] FabricGateway - Have already been sending a request
[INFO] FabricGateway - Have already been sending a request
[INFO] FabricGateway - Have already been sending a request
[INFO] FabricGateway - Have already been sending a request
```
- resolves `queryChainInfo` timeout error killing explorer.
```
[ERROR] Sync - <<<<<<<<<<<<<<<<<<<<<<<<<< Synchronizer Error >>>>>>>>>>>>>>>>>>>>>
[ERROR] Sync - FabricError: Query failed. Errors: ["Error: REQUEST TIMEOUT"]
    at SingleQueryHandler.evaluate (.../blockchain-explorer/node_modules/fabric-network/lib/impl/query/singlequeryhandler.js:47:23)
    at processTicksAndRejections (internal/process/task_queues.js:97:5)
    at async Transaction.evaluate (.../blockchain-explorer/node_modules/fabric-network/lib/transaction.js:276:25)
[INFO] Sync - <<<<<<<<<<<<<<<<<<<<<<<<<< Closing client processor >>>>>>>>>>>>>>>>>>>>>
[DEBUG] FabricEvent - disconnectEventHubs()
[DEBUG] FabricEvent - disconnectChannelEventHub(defaultchannel)
``` 