### PR TITLE
Bugfix: tailing ampersand sign prevents container from restarting

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -20,4 +20,4 @@ export LOG_CONSOLE_STDOUT=${LOG_CONSOLE_STDOUT:-false}
 export DISCOVERY_AS_LOCALHOST=${DISCOVERY_AS_LOCALHOST:-true}
 export EXPLORER_APP_ROOT=${EXPLORER_APP_ROOT:-dist}
 
-node ${EXPLORER_APP_ROOT}/main.js name - hyperledger-explorer &
+node ${EXPLORER_APP_ROOT}/main.js name - hyperledger-explorer


### PR DESCRIPTION
## This PR:
- removes trailing ampersand sign in start script which prevents docker container from restarting.

### Note: this has been reflected with @nekia, more [info](https://chat.hyperledger.org/channel/hyperledger-explorer?msg=Hf6nkhLoNfFazXbNW) here.