### PR TITLE
Fix script to specify the BC Exprorer process

### DIFF
--- a/stop.sh
+++ b/stop.sh
@@ -4,7 +4,7 @@
 #    SPDX-License-Identifier: Apache-2.0
 #
 
-EXPLORER_PROCESS_ID=$(ps aux  |  grep -v "awk"  |  awk '/name - hyperledger-explorer/ {print $2}')
+EXPLORER_PROCESS_ID=$(ps -eo pid,args | grep -v "awk" | awk '/name - hyperledger-explorer/ {print $1}')
 
 if [ $EXPLORER_PROCESS_ID > 0 ]
 then


### PR DESCRIPTION
"stop.sh" uses "ps" command to identify the process ID of Explorer.

> ps aux | grep -v "awk" | awk '/name - hyperledger-explorer/ {print $2}'

But Alpine Linux, which is used by Explorer container, returns the following values for "ps" command.

PID   USER   TIME    COMMAND
45     root     0:12    node app/main.js name - hyperledger-explorer

So correct process ID cannot be obtained by the above method. (Misidentify "root" as process ID.) 
It works correctly by specifying the format of the output of "ps" command like follows.

> ps **-eo pid,args** | grep -v "awk" | awk '/name - hyperledger-explorer/ {print $1}'