### PR TITLE
BE-874 Fix script to specify the BC Exprorer process

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -398,9 +398,7 @@
 					"sqlcharacter",
 					"peerlist",
 					"www",
-					"craetedat",
-					"tcp",
-					"appender"
+					"craetedat"
 				],
 				"skipWordIfMatch": [
 					"^\\d+px",

--- a/app/common/commonUtils.ts
+++ b/app/common/commonUtils.ts
@@ -1,0 +1,25 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { helper } from './helper';
+
+const logger = helper.getLogger('ForkSenderHandler');
+
+/**
+ * Returns the number of milliseconds between midnight,
+ * January 1, 1970 Universal Coordinated Time (UTC) (or GMT) and the specified date.
+ *
+ * @param {*} dateStr
+ * @returns
+ */
+
+export function toUTCmilliseconds(dateStr: any) {
+	let startSyncMills = null;
+	try {
+		startSyncMills = Date.parse(dateStr);
+	} catch (err) {
+		logger.error('Unparsable date format, dateStr= ', dateStr, ' ', err);
+	}
+	return startSyncMills;
+}

--- a/app/common/helper.ts
+++ b/app/common/helper.ts
@@ -68,68 +68,45 @@ export class helper {
 			consoleLevel = process.env.LOG_LEVEL_CONSOLE;
 		}
 
-		let logConfig: any = {};
-		if (!yn(process.env.FORK)) {
-			logConfig = {
-				appenders: {
-					app: {
-						type: 'dateFile',
-						filename: appLog,
-						maxLogSize: 8 * 1024 * 1024,
-						daysToKeep: 7
-					},
-					db: {
-						type: 'dateFile',
-						filename: dbLog,
-						maxLogSize: 8 * 1024 * 1024,
-						daysToKeep: 7
-					},
-					console: {
-						type: 'dateFile',
-						filename: consoleLog,
-						maxLogSize: 8 * 1024 * 1024,
-						daysToKeep: 7
-					},
-					consoleFilter: {
-						type: 'logLevelFilter',
-						appender: 'console',
-						level: consoleLevel
-					}
+		const logConfig = {
+			appenders: {
+				app: {
+					type: 'dateFile',
+					filename: appLog,
+					maxLogSize: 8 * 1024 * 1024,
+					daysToKeep: 7
 				},
-				categories: {
-					default: { appenders: ['consoleFilter', 'app'], level: appLevel },
-					PgService: { appenders: ['consoleFilter', 'db'], level: dbLevel }
+				db: {
+					type: 'dateFile',
+					filename: dbLog,
+					maxLogSize: 8 * 1024 * 1024,
+					daysToKeep: 7
+				},
+				console: {
+					type: 'dateFile',
+					filename: consoleLog,
+					maxLogSize: 8 * 1024 * 1024,
+					daysToKeep: 7
+				},
+				consoleFilter: {
+					type: 'logLevelFilter',
+					appender: 'console',
+					level: consoleLevel
 				}
-			};
+			},
+			categories: {
+				default: { appenders: ['consoleFilter', 'app'], level: appLevel },
+				PgService: { appenders: ['consoleFilter', 'db'], level: dbLevel }
+			}
+		};
 
-			if (moduleName === 'main') {
-				// Should initiate logger once with tcp-server appender
-				logConfig.appenders = {
-					...logConfig.appenders,
-					server: { type: 'tcp-server' }
+		if (process.env.LOG_CONSOLE_STDOUT) {
+			if (yn(process.env.LOG_CONSOLE_STDOUT)) {
+				logConfig.appenders.console = {
+					...logConfig.appenders.console,
+					type: 'console'
 				};
 			}
-
-			if (process.env.LOG_CONSOLE_STDOUT) {
-				if (yn(process.env.LOG_CONSOLE_STDOUT)) {
-					logConfig.appenders.console = {
-						...logConfig.appenders.console,
-						type: 'console'
-					};
-				}
-			}
-		} else {
-			logConfig = {
-				appenders: {
-					network: {
-						type: 'tcp'
-					}
-				},
-				categories: {
-					default: { appenders: ['network'], level: appLevel },
-					PgService: { appenders: ['network'], level: dbLevel }
-				}
-			};
 		}
 
 		log4js.configure(logConfig);

--- a/app/sync/listener/ForkListenerHandler.ts
+++ b/app/sync/listener/ForkListenerHandler.ts
@@ -31,13 +31,7 @@ export class ForkListenerHandler {
 	 * @memberof ForkListenerHandler
 	 */
 	async initialize(args) {
-		this.syncProcessor = fork(path.resolve(__dirname, '../../sync.js'), args, {
-			env: {
-				...process.env,
-				// Mark forked process explicitly for logging using TCP server
-				FORK: '1'
-			}
-		});
+		this.syncProcessor = fork(path.resolve(__dirname, '../../sync.js'), args);
 
 		this.syncProcessor.on('message', msg => {
 			this.platform.getProxy().processSyncMessage(msg);

--- a/stop.sh
+++ b/stop.sh
@@ -4,7 +4,7 @@
 #    SPDX-License-Identifier: Apache-2.0
 #
 
-EXPLORER_PROCESS_ID=$(ps aux  |  grep -v "awk"  |  awk '/name - hyperledger-explorer/ {print $2}')
+EXPLORER_PROCESS_ID=$(ps -eo pid,args | grep -v "awk" | awk '/name - hyperledger-explorer/ {print $1}')
 
 if [ $EXPLORER_PROCESS_ID > 0 ]
 then


### PR DESCRIPTION
"stop.sh" uses "ps" command to identify the process ID of Explorer.

> ps aux | grep -v "awk" | awk '/name - hyperledger-explorer/ {print $2}'

But Alpine Linux, which is used by Explorer container, returns the following values for "ps" command.

> PID USER TIME COMMAND
> 45 root 0:12 node app/main.js name - hyperledger-explorer

So correct process ID cannot be obtained by the above method. (Misidentify "root" as process ID.)
It works correctly by specifying the format of the output of "ps" command like follows.

> ps -eo pid,args | grep -v "awk" | awk '/name - hyperledger-explorer/ {print $1}'