### PR TITLE
Fix: convert-hex can’t convert Buffer to Hex properly

### DIFF
--- a/app/platform/fabric/sync/SyncService.ts
+++ b/app/platform/fabric/sync/SyncService.ts
@@ -2,7 +2,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as convertHex from 'convert-hex';
 import fabprotos from 'fabric-protos';
 import includes from 'lodash/includes';
 import * as sha from 'js-sha256';
@@ -554,15 +553,15 @@ export class SyncServices {
 			}
 			let envelope_signature = txObj.signature;
 			if (envelope_signature !== undefined) {
-				envelope_signature = convertHex.bytesToHex(envelope_signature);
+				envelope_signature = Buffer.from(envelope_signature).toString('hex');
 			}
 			let payload_extension = txObj.payload.header.channel_header.extension;
 			if (payload_extension !== undefined) {
-				payload_extension = convertHex.bytesToHex(payload_extension);
+				payload_extension = Buffer.from(payload_extension).toString('hex');
 			}
 			let creator_nonce = txObj.payload.header.signature_header.nonce;
 			if (creator_nonce !== undefined) {
-				creator_nonce = convertHex.bytesToHex(creator_nonce);
+				creator_nonce = Buffer.from(creator_nonce).toString('hex');
 			}
 			/* eslint-disable */
 			const creator_id_bytes =
@@ -598,14 +597,15 @@ export class SyncServices {
 					let inputs = '';
 					for (const input of chaincode_proposal_input) {
 						inputs =
-							(inputs === '' ? inputs : `${inputs},`) + convertHex.bytesToHex(input);
+							(inputs === '' ? inputs : `${inputs},`) +
+							Buffer.from(input).toString('hex');
 					}
 					chaincode_proposal_input = inputs;
 				}
 				endorser_signature =
 					txObj.payload.data.actions[0].payload.action.endorsements[0].signature;
 				if (endorser_signature !== undefined) {
-					endorser_signature = convertHex.bytesToHex(endorser_signature);
+					endorser_signature = Buffer.from(endorser_signature).toString('hex');
 				}
 				payload_proposal_hash = txObj.payload.data.actions[0].payload.action.proposal_response_payload.proposal_hash.toString(
 					'hex'

--- a/app/platform/fabric/sync/SyncService.ts
+++ b/app/platform/fabric/sync/SyncService.ts
@@ -554,29 +554,14 @@ export class SyncServices {
 			}
 			let envelope_signature = txObj.signature;
 			if (envelope_signature !== undefined) {
-				console.log('-----envelope_signature-----');
-				console.log('raw:', envelope_signature);
-				console.log('convertHex:', convertHex.bytesToHex(envelope_signature));
-				console.log('toString:', Buffer.from(envelope_signature).toString('hex'));
-				console.log('++++++++++++++++++++++++++++');
 				envelope_signature = convertHex.bytesToHex(envelope_signature);
 			}
 			let payload_extension = txObj.payload.header.channel_header.extension;
 			if (payload_extension !== undefined) {
-				console.log('-----payload_extension-----');
-				console.log('raw:', payload_extension);
-				console.log('convertHex:', convertHex.bytesToHex(payload_extension));
-				console.log('toString:', Buffer.from(payload_extension).toString('hex'));
-				console.log('+++++++++++++++++++++++++++');
 				payload_extension = convertHex.bytesToHex(payload_extension);
 			}
 			let creator_nonce = txObj.payload.header.signature_header.nonce;
 			if (creator_nonce !== undefined) {
-				console.log('-----creator_nonce-----');
-				console.log('raw:', creator_nonce);
-				console.log('convertHex:', convertHex.bytesToHex(creator_nonce));
-				console.log('toString:', Buffer.from(creator_nonce).toString('hex'));
-				console.log('+++++++++++++++++++++++');
 				creator_nonce = convertHex.bytesToHex(creator_nonce);
 			}
 			/* eslint-disable */
@@ -614,22 +599,12 @@ export class SyncServices {
 					for (const input of chaincode_proposal_input) {
 						inputs =
 							(inputs === '' ? inputs : `${inputs},`) + convertHex.bytesToHex(input);
-						console.log('-----input-----');
-						console.log('raw:', input);
-						console.log('convertHex:', convertHex.bytesToHex(input));
-						console.log('toString:', Buffer.from(input).toString('hex'));
-						console.log('+++++++++++++++');
 					}
 					chaincode_proposal_input = inputs;
 				}
 				endorser_signature =
 					txObj.payload.data.actions[0].payload.action.endorsements[0].signature;
 				if (endorser_signature !== undefined) {
-					console.log('-----endorser_signature-----');
-					console.log(endorser_signature);
-					console.log('convertHex:', convertHex.bytesToHex(endorser_signature));
-					console.log('toString:', Buffer.from(endorser_signature).toString('hex'));
-					console.log('++++++++++++++++++++++++++++');
 					endorser_signature = convertHex.bytesToHex(endorser_signature);
 				}
 				payload_proposal_hash = txObj.payload.data.actions[0].payload.action.proposal_response_payload.proposal_hash.toString(

--- a/app/platform/fabric/sync/SyncService.ts
+++ b/app/platform/fabric/sync/SyncService.ts
@@ -554,14 +554,29 @@ export class SyncServices {
 			}
 			let envelope_signature = txObj.signature;
 			if (envelope_signature !== undefined) {
+				console.log('-----envelope_signature-----');
+				console.log('raw:', envelope_signature);
+				console.log('convertHex:', convertHex.bytesToHex(envelope_signature));
+				console.log('toString:', Buffer.from(envelope_signature).toString('hex'));
+				console.log('++++++++++++++++++++++++++++');
 				envelope_signature = convertHex.bytesToHex(envelope_signature);
 			}
 			let payload_extension = txObj.payload.header.channel_header.extension;
 			if (payload_extension !== undefined) {
+				console.log('-----payload_extension-----');
+				console.log('raw:', payload_extension);
+				console.log('convertHex:', convertHex.bytesToHex(payload_extension));
+				console.log('toString:', Buffer.from(payload_extension).toString('hex'));
+				console.log('+++++++++++++++++++++++++++');
 				payload_extension = convertHex.bytesToHex(payload_extension);
 			}
 			let creator_nonce = txObj.payload.header.signature_header.nonce;
 			if (creator_nonce !== undefined) {
+				console.log('-----creator_nonce-----');
+				console.log('raw:', creator_nonce);
+				console.log('convertHex:', convertHex.bytesToHex(creator_nonce));
+				console.log('toString:', Buffer.from(creator_nonce).toString('hex'));
+				console.log('+++++++++++++++++++++++');
 				creator_nonce = convertHex.bytesToHex(creator_nonce);
 			}
 			/* eslint-disable */
@@ -599,12 +614,22 @@ export class SyncServices {
 					for (const input of chaincode_proposal_input) {
 						inputs =
 							(inputs === '' ? inputs : `${inputs},`) + convertHex.bytesToHex(input);
+						console.log('-----input-----');
+						console.log('raw:', input);
+						console.log('convertHex:', convertHex.bytesToHex(input));
+						console.log('toString:', Buffer.from(input).toString('hex'));
+						console.log('+++++++++++++++');
 					}
 					chaincode_proposal_input = inputs;
 				}
 				endorser_signature =
 					txObj.payload.data.actions[0].payload.action.endorsements[0].signature;
 				if (endorser_signature !== undefined) {
+					console.log('-----endorser_signature-----');
+					console.log(endorser_signature);
+					console.log('convertHex:', convertHex.bytesToHex(endorser_signature));
+					console.log('toString:', Buffer.from(endorser_signature).toString('hex'));
+					console.log('++++++++++++++++++++++++++++');
 					endorser_signature = convertHex.bytesToHex(endorser_signature);
 				}
 				payload_proposal_hash = txObj.payload.data.actions[0].payload.action.proposal_response_payload.proposal_hash.toString(

--- a/app/test/SyncService.test.ts
+++ b/app/test/SyncService.test.ts
@@ -35,9 +35,6 @@ function getSyncServicesInstance() {
 	const { SyncServices } = proxyquire
 		.noCallThru()
 		.load('../platform/fabric/sync/SyncService', {
-			'convert-hex': {
-				bytesToHex: sinon.stub()
-			},
 			'../../../common/helper': {
 				helper: {
 					getLogger: function() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2050,11 +2050,6 @@
 			"resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
 			"integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
 		},
-		"convert-hex": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/convert-hex/-/convert-hex-0.1.0.tgz",
-			"integrity": "sha1-CMBFaJIsJ3drii6BqV05M2LqC2U="
-		},
 		"convert-source-map": {
 			"version": "1.8.0",
 			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.8.0.tgz",
@@ -7808,6 +7803,37 @@
 			"integrity": "sha1-NBeKx7uO4pTMXVVK2LUPf1RZ/Y4=",
 			"requires": {
 				"websocket": "^1.0.34"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"optional": true,
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+					"optional": true
+				},
+				"websocket": {
+					"version": "1.0.34",
+					"resolved": "https://registry.npmjs.org/websocket/-/websocket-1.0.34.tgz",
+					"integrity": "sha512-PRDso2sGwF6kM75QykIesBijKSVceR6jL2G8NGYyq2XrItNC2P5/qL5XeR056GhA+Ly7JMFvJb9I312mJfmqnQ==",
+					"optional": true,
+					"requires": {
+						"bufferutil": "^4.0.1",
+						"debug": "^2.2.0",
+						"es5-ext": "^0.10.50",
+						"typedarray-to-buffer": "^3.1.5",
+						"utf-8-validate": "^5.0.2",
+						"yaeti": "^0.0.6"
+					}
+				}
 			}
 		},
 		"stream-combiner": {
@@ -8439,37 +8465,6 @@
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
 			"integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
-		},
-		"websocket": {
-			"version": "1.0.34",
-			"resolved": "https://registry.npmjs.org/websocket/-/websocket-1.0.34.tgz",
-			"integrity": "sha512-PRDso2sGwF6kM75QykIesBijKSVceR6jL2G8NGYyq2XrItNC2P5/qL5XeR056GhA+Ly7JMFvJb9I312mJfmqnQ==",
-			"optional": true,
-			"requires": {
-				"bufferutil": "^4.0.1",
-				"debug": "^2.2.0",
-				"es5-ext": "^0.10.50",
-				"typedarray-to-buffer": "^3.1.5",
-				"utf-8-validate": "^5.0.2",
-				"yaeti": "^0.0.6"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "2.6.9",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-					"optional": true,
-					"requires": {
-						"ms": "2.0.0"
-					}
-				},
-				"ms": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-					"optional": true
-				}
-			}
 		},
 		"which": {
 			"version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
 		"classnames": "^2.2.6",
 		"co": "^4.6.0",
 		"compression": "^1.7.2",
-		"convert-hex": "^0.1.0",
 		"ejs": "^2.5.6",
 		"enum": "^2.5.0",
 		"eslint": "^7.26.0",


### PR DESCRIPTION
# Bug
In explorer, you convert `envelope_signature`, `payload_extension`, `creator_nonce`, `input`, `endorser_signature` to Hex with `convertHex.bytesToHex`

`convertHex.bytesToHex` can’t deal with hex include `a` `b` `c` `d` `e`, for example, 
```node
const convertHex = require('convert-hex');

let test = Buffer.from('HELLO');
console.log(test.toString('hex'));
console.log(convertHex.bytesToHex(test));
```
`H` is `48`
`E` is `45`
`L` is `4c`
`O` is `4f`
`HELLO` should be `48454c4c4f`

But when I try to use `convertHex.bytesToHex`, the result is `4845000`. Those hex with `abcde` is converted into `0`

# Steps To Reproduce
Step1: Add some `console.log` to explore (in commit 7a3caeedae72181c8df54b929b85f7cee2cf6e5d), build a docker image. 
```bash
git checkout 7a3caeedae72181c8df54b929b85f7cee2cf6e5d
docker build -t hyperledger/explorer:1.1.3 . # BDK use image `hyperledger/explorer:1.1.3` by default.
```
Step2: Use [BDK](https://github.com/cathayddt/bdk) build a simple network with explorer for test
```bash
cd ~
git clone https://github.com/cathayddt/bdk.git
cd bdk

# Install the bdk
npm install
npm run build:console

# set network name
export BDK_NETWORK_NAME=explorer-test
. ./cicd/test_script/steps/set-params.sh

# create network
bdk network create -f ./cicd/test_script/network-create.json --create-full
. ./cicd/test_script/steps/peer-and-orderer-up.sh

# create channel
. ./cicd/test_script/steps/channel.sh

# start explorer
. ./cicd/test_script/steps/explorer.sh

# build and use chaincode
. ./cicd/test_script/steps/chaincode.sh
```
hint: BDK would create folder at `~/.bdk` and run several docker container. You can delete those after testing.

Step3: run `docker logs -f explorer.explorer-test` show explorer log.

The result show that `envelope_signature`, `payload_extension`, `creator_nonce`, `input`, `endorser_signature` is Buffer type, and `Buffer.from(xxx).toString(‘hex’)` work correctly: 
```
-----envelope_signature-----
raw: <Buffer 30 44 02 20 75 34 f8 ed 6f f0 e2 9f 74 53 73 35 54 5f ed c7 e8 22 bc c6 14 ff d8 79 44 21 2b 36 f0 dc 55 59 02 20 6d 55 b8 89 c7 34 fa 94 b2 1d b8 64 ... 20 more bytes>
convertHex: 3044220753400000074537335540000220014007944210360055592200550890340940006407432333401900201114075009926944
toString: 304402207534f8ed6ff0e29f74537335545fedc7e822bcc614ffd87944212b36f0dc555902206d55b889c734fa94b21db864b174323334a119d6a8201114e475fe3a99260944
++++++++++++++++++++++++++++
-----payload_extension-----
raw: <Buffer 12 08 12 06 66 61 62 63 61 72>
convertHex: 128126666162636172
toString: 12081206666162636172
+++++++++++++++++++++++++++
-----creator_nonce-----
raw: <Buffer 29 e2 19 8e 77 60 83 2a c6 23 92 27 33 91 8b 68 79 2a 16 31 6b 21 0d 21>
convertHex: 2901907760830023922733910687901631021021
toString: 29e2198e7760832ac623922733918b68792a16316b210d21
+++++++++++++++++++++++
-----input-----
raw: <Buffer 43 72 65 61 74 65 43 61 72>
convertHex: 437265617465436172
toString: 437265617465436172
+++++++++++++++
-----input-----
raw: <Buffer 43 41 52 5f 4f 52 47 33 5f 50 45 45 52 30>
convertHex: 4341520052473305045455230
toString: 4341525f4f5247335f5045455230
+++++++++++++++
-----input-----
raw: <Buffer 42 4d 57>
convertHex: 42057
toString: 424d57
+++++++++++++++
-----input-----
raw: <Buffer 58 36>
convertHex: 5836
toString: 5836
+++++++++++++++
-----input-----
raw: <Buffer 62 6c 75 65>
convertHex: 6207565
toString: 626c7565
+++++++++++++++
-----input-----
raw: <Buffer 4f 72 67 33>
convertHex: 0726733
toString: 4f726733
+++++++++++++++
-----endorser_signature-----
<Buffer 30 45 02 21 00 ec 52 51 c1 30 88 f4 85 82 c9 65 75 b7 08 11 95 67 3e 36 57 37 2d f1 30 b1 19 24 20 99 2a d0 69 02 20 6f 19 18 93 38 7b 1e c6 83 f4 c2 ... 21 more bytes>
convertHex: 3045221005251030880858206575081195670365737003001924209900692200191893380008300007250026470010000078930320
toString: 3045022100ec5251c13088f48582c96575b7081195673e3657372df130b1192420992ad06902206f191893387b1ec683f4c29d9f7205f78f26478af501b6ee6be6a67893c0320a
++++++++++++++++++++++++++++
```

# Solution
Use `Buffer.from(input).toString('hex')` rather then `convertHex.bytesToHex(input)`