### PR TITLE
BE-984 - fixed throw ExplorerError in FabricClient.ts

### DIFF
--- a/app/platform/fabric/FabricClient.ts
+++ b/app/platform/fabric/FabricClient.ts
@@ -57,7 +57,7 @@ export class FabricClient {
 		} catch (error) {
 			// TODO in case of the failure, should terminate explorer?
 			logger.error(error);
-			throw new ExplorerError(error);
+			throw new ExplorerError(explorerError.ERROR_1009);
 		}
 
 		// Getting channels from queryChannels


### PR DESCRIPTION
File: app/platform/fabric/FabricClient.ts
Error at line ExplorerError because its expecting string

try { 
// Use Gateway to connect to fabric network this.fabricGateway = new FabricGateway(this.config); await this.fabricGateway.initialize(); }
catch (error) { 
// TODO in case of the failure, should terminate explorer? 
logger.error(error); *throw new ExplorerError(error);* 
}