### PR TITLE
Fix ill-formed response by /api/peersStatus

### DIFF
--- a/app/platform/fabric/Proxy.ts
+++ b/app/platform/fabric/Proxy.ts
@@ -137,12 +137,14 @@ export class Proxy {
 							node.ledger_height_unsigned = peer.ledgerHeight.unsigned;
 						}
 					}
-				} else {
-					// Sometime 'peers_by_org' property is not included in discover result
-					node.ledger_height_low = '-';
-					node.ledger_height_high = '-';
-					node.ledger_height_unsigned = '-';
 				}
+				// Sometime 'peers_by_org' property is not included in discover result
+				if(typeof node.ledger_height_low === 'undefined')
+                	node.ledger_height_low = '-';
+				if(typeof node.ledger_height_high === 'undefined')
+					node.ledger_height_high = '-';
+				if(typeof node.ledger_height_unsigned === 'undefined')
+					node.ledger_height_unsigned = '-';
 				peers.push(node);
 			} else if (node.peer_type === 'ORDERER') {
 				node.status = 'DOWN';


### PR DESCRIPTION
After setting up explorer, I was getting this error when switching to the 'Network' Tab of the client view.
![image](https://user-images.githubusercontent.com/16841301/166065469-5a58dad7-b622-4f96-80b5-486fe4190a98.png)

Found out it was coming from Peer.js
![image](https://user-images.githubusercontent.com/16841301/166065519-1c2d8c55-7d1f-4c05-84a0-8056db7e1020.png)

Upon further investigation I found that the client would sometimes receive ill-formed json responses.
![image](https://user-images.githubusercontent.com/16841301/166065627-661f4827-c260-44d5-a018-2ea1a28cffab.png)

Then I checked the request 
![image](https://user-images.githubusercontent.com/16841301/166065779-fb32cd91-0c6b-4047-bce9-28f6681a5fbd.png)

Upon going through the api, found out that for some cases [Proxy:getPeersStatus()](https://github.com/hyperledger/blockchain-explorer/blob/3950864ac4027374a664e327be5e98966dc34699/app/platform/fabric/Proxy.ts#L108) would return ill-formed JSON.

I have changed a few lines to cover those situations.

Signed-off-by: kaushikkumarbora <kaushikkumarbora@gmail.com>