### PR TITLE
daysToKeep deprecation - keep daily logs

### DIFF
--- a/app/common/helper.ts
+++ b/app/common/helper.ts
@@ -75,20 +75,17 @@ export class helper {
 					app: {
 						type: 'dateFile',
 						filename: appLog,
-						maxLogSize: 8 * 1024 * 1024,
-						daysToKeep: 7
+						numBackups: 7
 					},
 					db: {
 						type: 'dateFile',
 						filename: dbLog,
-						maxLogSize: 8 * 1024 * 1024,
-						daysToKeep: 7
+						numBackups: 7
 					},
 					console: {
 						type: 'dateFile',
 						filename: consoleLog,
-						maxLogSize: 8 * 1024 * 1024,
-						daysToKeep: 7
+						numBackups: 7
 					},
 					consoleFilter: {
 						type: 'logLevelFilter',


### PR DESCRIPTION
The log option 'daysToKeep' is deprecated without any replacement available. Suggested change is to use `numBackups`; unfortunately, `maxLogSize` generates an unpredictable number of logs per time, so ensuring that a full week of logs is retained is incompatible with the migration. (A possible workaround would be setting `numBackups: 1000000000`, or some other ludicrously-high value, but even this isn't perfectly guaranteed to include a full week if something goes wrong that generates a massive amount of logs.)

This change will eventually be necessary. Currently it is not, but leaving the deprecation present generates a long list of warnings when built (true since #272); this will suppress those.