### PR TITLE
Customize Quick-Start docs by OS

### DIFF
--- a/README.md
+++ b/README.md
@@ -408,6 +408,10 @@ $ DISCOVERY_AS_LOCALHOST=false npm start
 $ DISCOVERY_AS_LOCALHOST=false ./syncstart.sh
 ```
 
+# Updating Docker image
+
+To build a new version of the Docker image, use `npm run-script docker_build`. This creates a new image, which will become `hyperledger-explorer:latest` (distinct from the canonical images, which are `hyperledger/explorer`, with a `/`). This is a distinct build from the local version used in the Quick Start process. Run this image with `docker-compose down && docker-compose up -d`; both commands are needed.
+
 # Configuration
 
 Please refer [README-CONFIG.md](README-CONFIG.md) for more detail on each configuration.

--- a/README.md
+++ b/README.md
@@ -275,58 +275,80 @@ $ cd blockchain-explorer/app
     ```
     $ cd blockchain-explorer/app/persistence/fabric/postgreSQL/db
     $ ./createdb.sh
+    $ createdb `whoami`
     ```
 
 Connect to the PostgreSQL database and run DB status commands:
 
+* **Ubuntu**
+
+    ```shell
+    sudo -u postgres psql -c '\l'
+    sudo -u postgres psql $DATABASE_DATABASE -c '\d'
+    ```
+
+* **MacOS**
+
+    ```shell
+    psql -c '\l'
+    psql $DATABASE_DATABASE -c '\d'
+    ```
+
+Expected output
 ```shell
 $ sudo -u postgres psql -c '\l'
-                                List of databases
-      Name      |  Owner   | Encoding | Collate |  Ctype  |   Access privileges
-----------------+----------+----------+---------+---------+-----------------------
- fabricexplorer | hppoc    | UTF8     | C.UTF-8 | C.UTF-8 |
- postgres       | postgres | UTF8     | C.UTF-8 | C.UTF-8 |
- template0      | postgres | UTF8     | C.UTF-8 | C.UTF-8 | =c/postgres          +
-                |          |          |         |         | postgres=CTc/postgres
- template1      | postgres | UTF8     | C.UTF-8 | C.UTF-8 | =c/postgres          +
-                |          |          |         |         | postgres=CTc/postgres
+                                     List of databases
+      Name      |        Owner        | Encoding | Collate |  Ctype  |   Access privileges
+----------------+---------------------+----------+---------+---------+-----------------------
+ fabricexplorer | $DATABASE_USERNAME  | UTF8     | C.UTF-8 | C.UTF-8 |
+ postgres       | postgres            | UTF8     | C.UTF-8 | C.UTF-8 |
+ template0      | postgres            | UTF8     | C.UTF-8 | C.UTF-8 | =c/postgres          +
+                |                     |          |         |         | postgres=CTc/postgres
+ template1      | postgres            | UTF8     | C.UTF-8 | C.UTF-8 | =c/postgres          +
+                |                     |          |         |         | postgres=CTc/postgres
 (4 rows)
 
-$ sudo -u postgres psql fabricexplorer -c '\d'
+$ sudo -u postgres psql $DATABASE_DATABASE -c '\d'
                    List of relations
- Schema |           Name            |   Type   | Owner
---------+---------------------------+----------+-------
- public | blocks                    | table    | hppoc
- public | blocks_id_seq             | sequence | hppoc
- public | chaincodes                | table    | hppoc
- public | chaincodes_id_seq         | sequence | hppoc
- public | channel                   | table    | hppoc
- public | channel_id_seq            | sequence | hppoc
- public | orderer                   | table    | hppoc
- public | orderer_id_seq            | sequence | hppoc
- public | peer                      | table    | hppoc
- public | peer_id_seq               | sequence | hppoc
- public | peer_ref_chaincode        | table    | hppoc
- public | peer_ref_chaincode_id_seq | sequence | hppoc
- public | peer_ref_channel          | table    | hppoc
- public | peer_ref_channel_id_seq   | sequence | hppoc
- public | transactions              | table    | hppoc
- public | transactions_id_seq       | sequence | hppoc
- public | write_lock                | table    | hppoc
- public | write_lock_write_lock_seq | sequence | hppoc
+ Schema |           Name            |   Type   |       Owner
+--------+---------------------------+----------+-------------------
+ public | blocks                    | table    | $DATABASE_USERNAME
+ public | blocks_id_seq             | sequence | $DATABASE_USERNAME
+ public | chaincodes                | table    | $DATABASE_USERNAME
+ public | chaincodes_id_seq         | sequence | $DATABASE_USERNAME
+ public | channel                   | table    | $DATABASE_USERNAME
+ public | channel_id_seq            | sequence | $DATABASE_USERNAME
+ public | orderer                   | table    | $DATABASE_USERNAME
+ public | orderer_id_seq            | sequence | $DATABASE_USERNAME
+ public | peer                      | table    | $DATABASE_USERNAME
+ public | peer_id_seq               | sequence | $DATABASE_USERNAME
+ public | peer_ref_chaincode        | table    | $DATABASE_USERNAME
+ public | peer_ref_chaincode_id_seq | sequence | $DATABASE_USERNAME
+ public | peer_ref_channel          | table    | $DATABASE_USERNAME
+ public | peer_ref_channel_id_seq   | sequence | $DATABASE_USERNAME
+ public | transactions              | table    | $DATABASE_USERNAME
+ public | transactions_id_seq       | sequence | $DATABASE_USERNAME
+ public | write_lock                | table    | $DATABASE_USERNAME
+ public | write_lock_write_lock_seq | sequence | $DATABASE_USERNAME
 (18 rows)
 
 ```
+
+(On MacOS, expect to see your `` `whoami` `` rather than `postgres`. Entries with
+`$DATABASE_USERNAME` will have the valuei of that parameter, whether set as an
+environment variable or as a JSON keyval; it will not show the literal string.)
 
 ## Build Hyperledger Explorer
 
 **Important:** repeat the below steps after every git pull
 
-* `./main.sh install`
-  * To install, run tests, and build project
+From the root of the repository:
+
 - `./main.sh clean`
   * To clean the /node_modules, client/node_modules client/build, client/coverage, app/test/node_modules
    directories
+* `./main.sh install`
+  * To install, run tests, and build project
 
 Or
 


### PR DESCRIPTION
Commands and portions of results are different on Linux vs. MacOS, and this is not reflected in the docs. Updated to correct that.

Also, add a small piece explaining how to generate a new Docker image from this repository. It already doesn't use the same name as the canonical image (`hyperledger-explorer` rather than `hyperledger/explorer`), so this is not going to pollute the image repository and is unlikely to cause confusion unless someone deliberately tries to mess with it.

The second part is useful for developers who want to test changes to the image and/or create forks of the project. It would have saved me some time - I made an unwarranted assumption about the local install/build process also creating images and took a while to correct that.