### PR TITLE
Two small tweaks for ease of use

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,7 +351,7 @@ $ npm run build
     ```
 
 * `npm start`
-  * It will have the backend and GUI service up
+  * It will have the backend and GUI service up, for as long as the process runs
 
 * `npm run app-stop`
   * It will stop the node server

--- a/README.md
+++ b/README.md
@@ -277,7 +277,9 @@ $ cd blockchain-explorer/app
     $ ./createdb.sh
     ```
 
-Connect to the PostgreSQL database and run DB status commands:
+Connect to the PostgreSQL database and run DB status commands. To export the
+settings from `app/explorerconfig.json` to the environment, run `source
+app/exportConfig.sh`; this will set `$DATABASE_DATABASE` and related envvars.
 
 ```shell
 $ sudo -u postgres psql -c '\l'

--- a/app/exportConfig.sh
+++ b/app/exportConfig.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+echo "should be sourced"
+jq . ./explorerconfig.json >/dev/null
+
+export DATABASE_HOST=$(jq -r '.postgreSQL.host' ./explorerconfig.json)
+export DATABASE_PORT=$(jq -r '.postgreSQL.port' ./explorerconfig.json)
+export DATABASE_USERNAME=$(jq -r '.postgreSQL.username' ./explorerconfig.json)
+export DATABASE_DATABASE=$(jq -r '.postgreSQL.database' ./explorerconfig.json)
+export DATABASE_PASSWD=$(jq -r '.postgreSQL.passwd' ./explorerconfig.json)

--- a/start.sh
+++ b/start.sh
@@ -20,4 +20,11 @@ export LOG_CONSOLE_STDOUT=${LOG_CONSOLE_STDOUT:-false}
 export DISCOVERY_AS_LOCALHOST=${DISCOVERY_AS_LOCALHOST:-true}
 export EXPLORER_APP_ROOT=${EXPLORER_APP_ROOT:-dist}
 
+function log_exit() {
+  echo "Server stopped"
+  exit
+}
+trap log_exit SIGINT EXIT
+echo "Server running..."
+
 node ${EXPLORER_APP_ROOT}/main.js name - hyperledger-explorer


### PR DESCRIPTION
- script that exports DB settings from `app/explorerconfig.json` to the envvars, which makes it easier to use the example commands in the Quick Start
- script and doc tweaks to make it clear that `npm start` runs the app only while the process continues rather than in detached mode