### PR TITLE
Drop EXPOSE from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -63,8 +63,5 @@ COPY --from=BUILD_IMAGE $EXPLORER_APP_PATH/dist ./app/
 COPY --from=BUILD_IMAGE $EXPLORER_APP_PATH/client/build ./client/build/
 COPY --from=BUILD_IMAGE $EXPLORER_APP_PATH/node_modules ./node_modules/
 
-# expose default ports
-EXPOSE 8080
-
 # run blockchain explorer main app
 CMD npm run app-start && tail -f /dev/null


### PR DESCRIPTION
Follow-up for #301; not useful if that is rejected.

There doesn't seem to be a good way to make this respect a param or
envvar passed in, and it's not strictly *needed* if you're mapping ports.

Having it be present & incorrect in some cases is worse than having it
be absent in some cases where it would be correct. So just drop it
entirely.